### PR TITLE
chore: release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-03-17
+
 ### Added
 
 - Streaming HTTP API: `HttpStreamHandle` type and `http::stream_start`/`stream_read`/`stream_close` functions for consuming HTTP responses chunk-by-chunk (`astrid-sdk`)
@@ -30,6 +32,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/sdk-rust/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/unicity-astrid/sdk-rust/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,9 +15,9 @@ repository = "https://github.com/unicity-astrid/sdk-rust"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-sdk = { path = "astrid-sdk", version = "0.2.1" }
-astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.2.1" }
-astrid-sys = { path = "astrid-sys", version = "0.2.1" }
+astrid-sdk = { path = "astrid-sdk", version = "0.2.2" }
+astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.2.2" }
+astrid-sys = { path = "astrid-sys", version = "0.2.2" }
 astrid-types = { version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

Release 0.2.2 — streaming HTTP airlock API.

## Changes

- Workspace version 0.2.1 → 0.2.2
- CHANGELOG updated with 0.2.2 release date

## Test Plan

- [x] `cargo check --workspace` passes
- [x] All existing tests pass
- [ ] Tag `v0.2.2` after merge
- [ ] Publish `astrid-sys`, `astrid-sdk-macros`, `astrid-sdk` 0.2.2 to crates.io in dependency order