### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.*'
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          BODY=$(awk "/^## \\[$VERSION\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md)
+          if [ -z "$BODY" ]; then
+            BODY="See [CHANGELOG.md](https://github.com/unicity-astrid/sdk-rust/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details."
+          fi
+          {
+            echo "body<<EOF"
+            echo "$BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compile Astrinauts for this release
+        id: contributors
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p')
+          if [ -z "$PREV_TAG" ]; then
+            AUTHORS=$(git log --format='%aN' | sort -u)
+          else
+            AUTHORS=$(git log --format='%aN' "$PREV_TAG"..HEAD | sort -u)
+          fi
+          ASTRINAUTS=""
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            # Try to resolve GitHub username from commit email
+            EMAIL=$(git log --format='%aE' --author="$name" -1)
+            USERNAME=$(gh api "search/users?q=$EMAIL+in:email" --jq '.items[0].login // empty' 2>/dev/null || true)
+            if [ -n "$USERNAME" ]; then
+              ASTRINAUTS="${ASTRINAUTS}\n- @${USERNAME}"
+            else
+              ASTRINAUTS="${ASTRINAUTS}\n- ${name}"
+            fi
+          done <<< "$AUTHORS"
+          {
+            echo "list<<EOF"
+            echo -e "$ASTRINAUTS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: |
+            ${{ steps.changelog.outputs.body }}
+
+            ---
+
+            **With many thanks from the following Astrinauts** 🚀
+            ${{ steps.contributors.outputs.list }}


### PR DESCRIPTION
## Summary

- Add GitHub Actions release workflow (adapted from core) that triggers on `v*` tags
- Extracts changelog section, lists contributors, creates GitHub Release

## Changes

- Add `.github/workflows/release.yml`

## Test Plan

- [x] Workflow syntax matches core's proven release.yml