### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-17
+
+### Added
+
+- Doc comments as tool/capsule descriptions — `///` on `#[astrid::tool]` methods become `metadata.description` in the generated JSON schema. Doc comments on the `#[capsule]` impl block become the capsule-level description. Full doc text (all paragraphs) preserved for LLM context. (`astrid-sdk-macros`)
+- Inline mutable flag — `#[astrid::tool("name", mutable)]` or `#[astrid::tool(mutable)]` (name inferred from method). Standalone `#[astrid::mutable]` still works for backward compatibility. (`astrid-sdk-macros`)
+
+### Changed
+
+- Schema export format now returns `{ "tools": {...}, "description": "capsule doc" }` with backward compatibility when no capsule-level doc comment is present. (`astrid-sdk-macros`)
+
 ## [0.2.2] - 2026-03-17
 
 ### Added
@@ -32,7 +43,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/sdk-rust/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/unicity-astrid/sdk-rust/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/unicity-astrid/sdk-rust/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,9 +15,9 @@ repository = "https://github.com/unicity-astrid/sdk-rust"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-sdk = { path = "astrid-sdk", version = "0.2.2" }
-astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.2.2" }
-astrid-sys = { path = "astrid-sys", version = "0.2.2" }
+astrid-sdk = { path = "astrid-sdk", version = "0.3.0" }
+astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.3.0" }
+astrid-sys = { path = "astrid-sys", version = "0.3.0" }
 astrid-types = { version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

Release 0.3.0 — doc comments as descriptions, inline mutable flag.

## Changes

- Workspace version 0.2.2 → 0.3.0
- CHANGELOG updated with 0.3.0 entry

### Why minor bump?

Schema export format changed from a plain tools map to `{ "tools": {...}, "description": "..." }`. This is a public API change to the macro's generated output — any tooling parsing the schema export is affected.

## Test Plan

- [x] `cargo check --workspace` passes
- [x] All existing tests pass
- [ ] Tag `v0.3.0` after merge
- [ ] Publish `astrid-sys`, `astrid-sdk-macros`, `astrid-sdk` 0.3.0 to crates.io in dependency order