### PR TITLE
fix: #[capsule(state)] support, SysError dispatch, and stream-closed sentinel

### DIFF
--- a/astrid-sdk-macros/src/lib.rs
+++ b/astrid-sdk-macros/src/lib.rs
@@ -75,9 +75,11 @@ fn capsule_impl(
     let is_stateful = attr_is_stateful
         || input.items.iter().any(|item| {
             if let ImplItem::Fn(method) = item {
-                method.sig.inputs.iter().any(|arg| {
-                    matches!(arg, syn::FnArg::Receiver(r) if r.mutability.is_some())
-                })
+                method
+                    .sig
+                    .inputs
+                    .iter()
+                    .any(|arg| matches!(arg, syn::FnArg::Receiver(r) if r.mutability.is_some()))
             } else {
                 false
             }
@@ -1631,7 +1633,9 @@ mod tests {
         };
 
         let output = capsule_impl(attr, input).to_string();
-        let tool_pos = output.find("astrid_tool_call").expect("tool export missing");
+        let tool_pos = output
+            .find("astrid_tool_call")
+            .expect("tool export missing");
         let section = &output[tool_pos..];
         assert!(
             section.contains("get_json"),
@@ -1661,7 +1665,9 @@ mod tests {
             output.contains("get_instance"),
             "Stateless tool dispatch must use singleton via get_instance"
         );
-        let tool_pos = output.find("astrid_tool_call").expect("tool export missing");
+        let tool_pos = output
+            .find("astrid_tool_call")
+            .expect("tool export missing");
         let section = &output[tool_pos..];
         assert!(
             !section.contains("get_json"),
@@ -1687,7 +1693,9 @@ mod tests {
         };
 
         let output = capsule_impl(attr, input).to_string();
-        let pos = output.find("astrid_hook_trigger").expect("hook export missing");
+        let pos = output
+            .find("astrid_hook_trigger")
+            .expect("hook export missing");
         let section = &output[pos..];
         assert!(
             section.contains("get_json"),
@@ -1713,7 +1721,9 @@ mod tests {
         };
 
         let output = capsule_impl(attr, input).to_string();
-        let pos = output.find("astrid_command_run").expect("command export missing");
+        let pos = output
+            .find("astrid_command_run")
+            .expect("command export missing");
         let section = &output[pos..];
         assert!(
             section.contains("get_json"),
@@ -1739,7 +1749,9 @@ mod tests {
         };
 
         let output = capsule_impl(attr, input).to_string();
-        let pos = output.find("astrid_tool_call").expect("tool export missing");
+        let pos = output
+            .find("astrid_tool_call")
+            .expect("tool export missing");
         let section = &output[pos..];
         assert!(
             section.contains("get_json"),

--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -9,6 +9,11 @@ pub struct ListenerHandle(pub String);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamHandle(pub String);
 
+/// Sentinel byte written by the host when a peer disconnects cleanly (EOF /
+/// broken pipe). Matches `NET_STREAM_CLOSED` in the host `net.rs`. A single
+/// byte can never be a valid length-prefixed message so it is unambiguous.
+const STREAM_CLOSED_SENTINEL: &[u8] = &[0x01];
+
 /// Bind a Unix Domain Socket to the given path and return a listener handle.
 pub fn bind_unix(path: impl AsRef<[u8]>) -> Result<ListenerHandle, SysError> {
     let bytes = unsafe { astrid_net_bind_unix(path.as_ref().to_vec())? };
@@ -28,7 +33,7 @@ pub fn read(stream: &StreamHandle) -> Result<Vec<u8>, SysError> {
     let bytes = unsafe { astrid_net_read(stream.0.as_bytes().to_vec())? };
     // Sentinel [0x01] signals a clean peer disconnect (broken pipe / EOF).
     // The host writes this instead of trapping so the run loop can clean up.
-    if bytes == [0x01] {
+    if bytes == STREAM_CLOSED_SENTINEL {
         return Err(SysError::ApiError("stream closed".to_string()));
     }
     Ok(bytes)


### PR DESCRIPTION
Closes #9

## Summary

- **`#[capsule(state)]` attribute**: Parse `state` ident from the macro attr and OR with `&mut self` auto-detection. Previously `_attr` was silently ignored — tests expecting explicit opt-in to stateful dispatch were failing.
- **`SysError` dispatch fix**: Generated method calls now explicitly map errors via `Error::msg(e.to_string())` instead of relying on `?` to convert `SysError → WithReturnCode<Error>` (which isn't implemented). Fixes compile errors in stateful capsules.
- **`NET_STREAM_CLOSED` sentinel in `net::read`**: Host returns `[0x01]` on peer disconnect instead of trapping. SDK detects this sentinel and returns `Err(SysError::ApiError("stream closed"))` so capsule run loops can clean up dead streams without a WASM trap.
- **Tests**: Added stateful dispatch coverage for `#[astrid::tool]`, `#[astrid::interceptor]`, and `#[astrid::command]` with `&mut self`, plus stateless singleton path and explicit `#[capsule(state)]` forcing KV dispatch.

## Test plan

- [x] `cargo test -p astrid-sdk-macros` passes (40 tests)
- [x] Identity capsule builds with `--target wasm32-wasip1`
- [x] Consecutive `astrid -p` calls succeed without WASM trap in daemon logs