### PR TITLE
feat(net): mpsc-style channel API — recv/send/try_recv/try_accept

### DIFF
--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -70,9 +70,9 @@ enum ReadStatus {
 impl ReadStatus {
     fn from_byte(b: u8) -> Option<Self> {
         match b {
-            0x00 => Some(Self::Data),
-            0x01 => Some(Self::Closed),
-            0x02 => Some(Self::Pending),
+            b if b == Self::Data as u8 => Some(Self::Data),
+            b if b == Self::Closed as u8 => Some(Self::Closed),
+            b if b == Self::Pending as u8 => Some(Self::Pending),
             _ => None,
         }
     }
@@ -113,8 +113,13 @@ pub fn recv(stream: &StreamHandle) -> Result<Vec<u8>, RecvError> {
     loop {
         match try_recv(stream) {
             Ok(bytes) => return Ok(bytes),
-            Err(TryRecvError::Empty) => continue,
             Err(TryRecvError::Closed) => return Err(RecvError),
+            Err(TryRecvError::Empty) => {
+                // try_recv blocks in the host for up to 50ms per call, so this
+                // loop is not a true busy-wait. The sleep adds a small yield
+                // between host calls for good measure.
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
         }
     }
 }
@@ -136,7 +141,7 @@ pub fn try_recv(stream: &StreamHandle) -> Result<Vec<u8>, TryRecvError> {
         .and_then(|&b| ReadStatus::from_byte(b))
         .ok_or(TryRecvError::Closed)?;
     match status {
-        ReadStatus::Data => Ok(bytes.get(1..).unwrap_or_default().to_vec()),
+        ReadStatus::Data => Ok(bytes[1..].to_vec()),
         ReadStatus::Closed => Err(TryRecvError::Closed),
         ReadStatus::Pending => Err(TryRecvError::Empty),
     }


### PR DESCRIPTION
## Linked Issue

Closes #11

## Summary

Redesigns the net module to follow `std::sync::mpsc` conventions. Removes `read()`, `write()`, `poll_accept()` and replaces with idiomatic channel-style API. Decodes the `NetReadStatus` wire format from the paired core PR — no sentinel bytes visible in the public API.

## Changes

- `astrid-sdk/src/net.rs`: add `RecvError`, `TryRecvError`, `SendError`; add `recv`, `try_recv`, `send`, `try_accept`; add internal `ReadStatus` enum decoding the host wire format; remove `read`, `write`, `poll_accept`

## Test Plan

- [x] `cargo test -p astrid-sdk-macros` passes
- [x] CLI capsule builds with `--target wasm32-wasip1`
- [x] Three consecutive `astrid -p` calls all return LLM responses