### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-19
+
+### Added
+
+- `fs` module: `Metadata`, `DirEntry`, `ReadDir`, `FileType` types mirroring `std::fs`. `read_dir()` returns an iterator, `metadata()` returns a typed struct with `.len()`, `.is_dir()`, `.is_file()`, `.modified()`. (`astrid-sdk`)
+- `http` module: typed `Request` builder (`get`/`post`/`put`/`delete`/`header`/`body`/`json`) and `Response` with `.bytes()`/`.text()`/`.json()`. `send()` and `stream_start()` take `&Request`. (`astrid-sdk`)
+- `net` module: `recv`/`try_recv`/`send`/`try_accept` with `RecvError`/`TryRecvError`/`SendError` mirroring `std::sync::mpsc`. `NetReadStatus` wire format with status-byte prefix replaces sentinel hack. (`astrid-sdk`)
+- `impl std::error::Error` for `RecvError`, `TryRecvError`, `SendError`. (`astrid-sdk`)
+- `#[capsule(state)]` attribute for explicit stateful opt-in alongside `&mut self` auto-detection. (`astrid-sdk-macros`)
+
+### Changed
+
+- `time::now_ms() -> Result<u64>` replaced by `time::now() -> Result<SystemTime>` using `std::time::SystemTime` directly. (`astrid-sdk`)
+- `log` functions take `impl Display` instead of `impl AsRef<[u8]>` for messages, `&str` for level. (`astrid-sdk`)
+- `fs` module extracted to its own file (`fs.rs`). (`astrid-sdk`)
+- Handle types (`ListenerHandle`, `StreamHandle`, `BackgroundProcessHandle`) inner fields are now private. (`astrid-sdk`)
+
+### Removed
+
+- `read()`, `write()`, `poll_accept()` from `net` module — replaced by `recv`/`send`/`try_accept`. (`astrid-sdk`)
+- `request_bytes()` from `http` module — replaced by `send(&Request)`. (`astrid-sdk`)
+- `now_ms()` from `time` module — replaced by `now()`. (`astrid-sdk`)
+
+### Fixed
+
+- `SysError` conversion in macro-generated dispatch code — `?` on method calls now maps `SysError` explicitly instead of relying on unimplemented `From<SysError> for WithReturnCode<Error>`. (`astrid-sdk-macros`)
+- `net::read` no longer traps on peer disconnect — uses `NetReadStatus` wire format instead of WASM trap. (`astrid-sdk`)
+
 ## [0.3.0] - 2026-03-17
 
 ### Added
@@ -43,7 +71,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/sdk-rust/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/sdk-rust/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/unicity-astrid/sdk-rust/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/unicity-astrid/sdk-rust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/unicity-astrid/sdk-rust/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,10 +15,10 @@ repository = "https://github.com/unicity-astrid/sdk-rust"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-sdk = { path = "astrid-sdk", version = "0.3.0" }
-astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.3.0" }
-astrid-sys = { path = "astrid-sys", version = "0.3.0" }
-astrid-types = { version = "0.3.0" }
+astrid-sdk = { path = "astrid-sdk", version = "0.4.0" }
+astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.4.0" }
+astrid-sys = { path = "astrid-sys", version = "0.4.0" }
+astrid-types = { version = "0.4.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"


### PR DESCRIPTION
## Summary

Release 0.4.0 — std-aligned API redesign.

## Changes

- Workspace version 0.3.0 → 0.4.0
- CHANGELOG updated with 0.4.0 entry

### Why minor bump?

Breaking API changes across fs, time, log, net, and http modules to align with Rust standard library conventions. See CHANGELOG for full details.

## Test Plan

- [x] `cargo check --workspace` passes
- [x] All existing tests pass
- [ ] Tag `v0.4.0` after merge
- [ ] Publish `astrid-sys`, `astrid-sdk-macros`, `astrid-sdk` 0.4.0 to crates.io in dependency order