### PR TITLE
fix(macros): tool_describe returns JSON bytes directly for hooks::trigger compatibility

### DIFF
--- a/astrid-sdk-macros/src/lib.rs
+++ b/astrid-sdk-macros/src/lib.rs
@@ -463,14 +463,9 @@ fn capsule_impl(
 
         hook_arms.push(quote! {
             "tool_describe" => {
-                // Deserialize the request to get the response topic
-                #[derive(::serde::Deserialize)]
-                struct __AstridToolDescribeRequest {
-                    response_topic: String,
-                }
-                let describe_req: __AstridToolDescribeRequest = ::serde_json::from_slice(&req.arguments)
-                    .map_err(|e| ::extism_pdk::Error::msg(format!("failed to parse tool_describe payload: {}", e)))?;
-
+                // Build tool schemas and return them directly as JSON bytes.
+                // The kernel's hooks::trigger() collects the return value from each
+                // interceptor — no response_topic IPC roundtrip needed.
                 let mut map: ::std::collections::BTreeMap<String, ::astrid_sdk::schemars::schema::RootSchema> = ::std::collections::BTreeMap::new();
                 #( #schema_arms )*
 
@@ -486,9 +481,8 @@ fn capsule_impl(
                         .map_err(|e| ::extism_pdk::Error::msg(format!("failed to serialize schemas: {}", e)))?
                 };
 
-                ::astrid_sdk::prelude::ipc::publish_json(&describe_req.response_topic, &response)
-                    .map_err(|e| ::extism_pdk::Error::msg(e.to_string()))?;
-                return Ok(vec![]);
+                ::serde_json::to_vec(&response)
+                    .map_err(|e| ::extism_pdk::Error::msg(format!("failed to serialize tool_describe response: {}", e)))
             }
         });
     }


### PR DESCRIPTION
## Summary

The `tool_describe` interceptor arm was parsing a `response_topic` field from the payload and publishing schemas to that IPC topic — this matched the old request/response IPC pattern.

It is incompatible with `hooks::trigger()`, which passes an empty `{}` payload and **collects each interceptor's return value directly**. The parse always failed with `missing field 'response_topic'`, so zero tool schemas were ever collected and the LLM had no tools.

## Changes

- `astrid-sdk-macros/src/lib.rs`: remove `response_topic` parsing from `tool_describe` arm; serialize schemas to JSON bytes and return them directly from the interceptor

## Test Plan

### Automated

- [x] SDK builds cleanly
- [x] No new clippy warnings

### Manual

- [ ] Build a tool capsule against this fix, run `astrid -p "what tools do you have?"` — should enumerate actual discovered tools via IPC, not a generic pre-trained response