### PR TITLE
fix(macros): wrap tool_describe return in Ok() for FnResult compatibility

### DIFF
--- a/astrid-sdk-macros/src/lib.rs
+++ b/astrid-sdk-macros/src/lib.rs
@@ -481,8 +481,8 @@ fn capsule_impl(
                         .map_err(|e| ::extism_pdk::Error::msg(format!("failed to serialize schemas: {}", e)))?
                 };
 
-                ::serde_json::to_vec(&response)
-                    .map_err(|e| ::extism_pdk::Error::msg(format!("failed to serialize tool_describe response: {}", e)))
+                Ok(::serde_json::to_vec(&response)
+                    .map_err(|e| ::extism_pdk::Error::msg(format!("failed to serialize tool_describe response: {}", e)))?)
             }
         });
     }


### PR DESCRIPTION
The `tool_describe` arm returned `Result<Vec<u8>, Error>` directly but `FnResult<T>` is `Result<T, WithReturnCode<Error>>`. Adding `?` propagates via `From<Error>` for `WithReturnCode<Error>` and `Ok()` wraps the success value correctly.

Fixes compilation of all capsules using `#[astrid::tool]`.