### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-10
+
 ### Breaking
 
 - **WASM engine migrated from Extism to wasmtime Component Model.** Capsules must be rebuilt targeting `wasm32-wasip2`. The `#[capsule]` macro now generates `impl Guest` + `export!()` instead of `extern "C"` exports. The ABI is completely different — existing `.wasm` binaries will not load. (#27)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 exclude = ["examples/test-capsule"]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.6.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ repository = "https://github.com/unicity-astrid/sdk-rust"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-sdk = { path = "astrid-sdk", version = "0.5.3" }
-astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.5.3" }
-astrid-sys = { path = "astrid-sys", version = "0.5.3" }
+astrid-sdk = { path = "astrid-sdk", version = "0.6.0" }
+astrid-sdk-macros = { path = "astrid-sdk-macros", version = "0.6.0" }
+astrid-sys = { path = "astrid-sys", version = "0.6.0" }
 astrid-types = { version = "0.4.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

Version bump 0.5.3 → 0.6.0.

### Changes since 0.5.3

**Breaking:**
- WASM engine migrated from Extism to wasmtime Component Model (wasm32-wasip2)
- All `&[u8]` parameters changed to `&str`
- Approval API simplified to 2 args (removed RiskLevel)
- Interceptor errors halt the chain (`"deny"` not `"error"`)
- `CallerContext` fields corrected
- `identity::link` returns `Result<()>`

**Removed:**
- `ipc::publish_bytes`, `poll_bytes`, `recv_bytes`, `publish_msgpack`
- `uplink::send_bytes`, `net::bind_unix(path)`, `hooks::trigger(&[u8])`
- `extism-pdk` and `rmp-serde` dependencies

**Added:**
- `wit_events!` proc macro — zero-duplication WIT → Rust type generation
- Serde derives on all WIT-generated types
- Typed IPC poll/recv with `PollResult`
- HTTP Response methods, `log::trace()`, mandatory WIT exports
- Shared `contracts` module with canonical IPC event types

### After merge

Tag `v0.6.0`, publish all three crates to crates.io:
```
cargo publish -p astrid-sys
cargo publish -p astrid-sdk-macros
cargo publish -p astrid-sdk
```