### PR TITLE
feat(sdk,wit): ipc-publish-as for uplink principal propagation

### DIFF
--- a/astrid-sdk/src/lib.rs
+++ b/astrid-sdk/src/lib.rs
@@ -161,6 +161,29 @@ pub mod ipc {
         publish(topic, &json)
     }
 
+    /// Publish a UTF-8 string payload on behalf of a specific principal.
+    ///
+    /// Like [`publish`] but stamps the outgoing envelope with the supplied
+    /// `principal` instead of this capsule's. Reserved for uplinks
+    /// (`uplink = true` in `Capsule.toml [capabilities]`) — the host
+    /// returns an error for any other caller. The trust model is "trust
+    /// the uplink": the kernel does not verify that the uplink actually
+    /// authenticated the claimed principal. See issue #658.
+    pub fn publish_as(topic: &str, payload: &str, principal: &str) -> Result<(), SysError> {
+        wit_ipc::ipc_publish_as(topic, payload, principal).map_err(SysError::HostError)
+    }
+
+    /// Publish a JSON-serialized value on behalf of a specific principal.
+    /// See [`publish_as`].
+    pub fn publish_json_as<T: Serialize>(
+        topic: &str,
+        payload: &T,
+        principal: &str,
+    ) -> Result<(), SysError> {
+        let json = serde_json::to_string(payload)?;
+        publish_as(topic, &json, principal)
+    }
+
     /// Subscribe to an IPC topic. Returns a typed handle for polling/receiving.
     pub fn subscribe(topic: &str) -> Result<SubscriptionHandle, SysError> {
         let handle_id = wit_ipc::ipc_subscribe(topic).map_err(SysError::HostError)?;

--- a/astrid-sys/wit/astrid-capsule.wit
+++ b/astrid-sys/wit/astrid-capsule.wit
@@ -411,6 +411,23 @@ interface ipc {
     /// is automatically propagated from the caller context.
     ipc-publish: func(topic: string, payload: string) -> result<_, string>;
 
+    /// Publish a message on behalf of a specific principal.
+    ///
+    /// Like `ipc-publish` but stamps the outgoing envelope with the
+    /// supplied principal instead of the capsule's own — used by
+    /// uplinks (CLI proxy, Telegram bridge, etc.) to relay messages
+    /// from external clients while preserving the calling identity
+    /// for downstream capability checks. Gated on `uplink = true` in
+    /// the manifest's `[capabilities]` block. The trust model is
+    /// "trust the uplink": the kernel does not verify that the uplink
+    /// actually authenticated the claimed principal. Real cross-
+    /// principal auth lives in issue #658.
+    ipc-publish-as: func(
+        topic: string,
+        payload: string,
+        principal: string,
+    ) -> result<_, string>;
+
     /// Subscribe to a topic pattern and receive a handle.
     ///
     /// Supports exact matches and trailing-suffix wildcards (`foo.bar.*`).


### PR DESCRIPTION
## Summary

Adds `ipc::publish_json_as(topic, payload, principal)` to the SDK and the matching `ipc-publish-as` host fn to the WIT contract. This is the SDK side of the uplink principal-propagation work — enables uplink capsules (CLI proxy, future Telegram/Discord bridges) to claim a principal other than their own owner so the kernel sees the actual invoking principal at the IPC boundary.

## Motivation

Without this, an uplink that fans inbound socket messages onto the bus stamps every published message with its own (capsule owner) principal. The kernel's Layer 5/6 enforcement preamble then sees `caller = default` regardless of which agent the operator is impersonating via the local CLI, and `astrid agent switch alice; astrid agent disable bob` silently succeeds as default.

## Changes

* `astrid-sdk/src/lib.rs`: new `ipc::publish_json_as` exported helper. Same signature as `publish_json` plus a trailing `principal: &str` argument. Routes to the new host fn.
* `astrid-sys/wit/astrid-capsule.wit`: new `ipc-publish-as: func(topic: string, payload: string, principal: string) -> result<_, string>` next to `ipc-publish`. Gated host-side by an `uplink: bool` capability — non-uplink capsules calling it get a clear error.

40 LOC.

## Companion PRs

* `unicity-astrid/astrid#719` — kernel side: implements the host fn, adds the `uplink: bool` capability gate, and stamps the CLI's outbound IPC with the active agent context.
* `unicity-astrid/capsule-cli#12` — uplink side: reads the `principal` field from inbound frames and republishes via `publish_json_as`.

This PR is the contract surface — both companion PRs depend on the SDK update landing first (or shipping in the next SDK release).

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] Manual integration test (in core): `agent switch alice; agent disable bob` correctly denies as alice instead of silently succeeding as default.