### PR TITLE
feat: source astrid-capsule.wit from canonical unicity-astrid/wit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,17 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
+  wit-sync:
+    name: Host WIT in sync with canonical
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Check host WIT mirror
+        run: scripts/sync-host-wit.sh --check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Changed
+
+- **`astrid-sys/wit/astrid-capsule.wit` is now sourced from `unicity-astrid/wit`.** The host ABI lived as an unsynced copy in three repos (kernel, sdk-rust, sdk-js). PR `unicity-astrid/wit#3` made `unicity-astrid/wit` the canonical home (new `host/astrid-capsule.wit` path). This repo's `contracts/` submodule pointer is bumped to that commit, and `astrid-sys/wit/astrid-capsule.wit` is now a sync artifact maintained by `scripts/sync-host-wit.sh`. Because `astrid-sys` publishes to crates.io and `cargo package` can only include files inside the crate dir, the file has to physically live where it does — but the canonical source is the submodule, and a new CI job (`wit-sync`) runs `scripts/sync-host-wit.sh --check` to fail drift. Bumps the in-crate WIT to include `ipc-publish-as` (previously only on `feat/ipc-publish-as` branch), which means the `wit-bindgen`-generated `astrid_sys::astrid::capsule::ipc::ipc_publish_as` binding is now available to guests on `main` — the Rust SDK wrapper (`astrid_sdk::ipc::publish_as`) still needs the host-side implementation to land before it can be reintroduced.
+
 ## [0.6.0] - 2026-04-10
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
-- **`astrid-sys/wit/astrid-capsule.wit` is now sourced from `unicity-astrid/wit`.** The host ABI lived as an unsynced copy in three repos (kernel, sdk-rust, sdk-js). PR `unicity-astrid/wit#3` made `unicity-astrid/wit` the canonical home (new `host/astrid-capsule.wit` path). This repo's `contracts/` submodule pointer is bumped to that commit, and `astrid-sys/wit/astrid-capsule.wit` is now a sync artifact maintained by `scripts/sync-host-wit.sh`. Because `astrid-sys` publishes to crates.io and `cargo package` can only include files inside the crate dir, the file has to physically live where it does — but the canonical source is the submodule, and a new CI job (`wit-sync`) runs `scripts/sync-host-wit.sh --check` to fail drift. Bumps the in-crate WIT to include `ipc-publish-as` (previously only on `feat/ipc-publish-as` branch), which means the `wit-bindgen`-generated `astrid_sys::astrid::capsule::ipc::ipc_publish_as` binding is now available to guests on `main` — the Rust SDK wrapper (`astrid_sdk::ipc::publish_as`) still needs the host-side implementation to land before it can be reintroduced.
+- **`astrid-sys/wit/astrid-capsule.wit` is now sourced from `unicity-astrid/wit`.** The host ABI lived as an unsynced copy in three repos (kernel, sdk-rust, sdk-js); PR `unicity-astrid/wit#3` made `unicity-astrid/wit` the canonical home (new `host/astrid-capsule.wit` path).
+  - This repo's `contracts/` submodule pointer is bumped to that commit.
+  - `astrid-sys/wit/astrid-capsule.wit` becomes a sync artifact maintained by `scripts/sync-host-wit.sh`. Can't go away entirely because `astrid-sys` publishes to crates.io and `cargo package` only bundles files inside the crate dir — but the submodule is authoritative.
+  - New CI job `wit-sync` runs `scripts/sync-host-wit.sh --check` on every push/PR. Drift between `contracts/host/` and `astrid-sys/wit/` fails CI.
+  - Bumps the in-crate WIT to include `ipc-publish-as` (previously only on `feat/ipc-publish-as`). The `wit-bindgen`-generated `astrid_sys::astrid::capsule::ipc::ipc_publish_as` binding is now available to guests on `main`. The Rust SDK wrapper (`astrid_sdk::ipc::publish_as`) still needs the host-side implementation to land before it can be reintroduced.
 
 ## [0.6.0] - 2026-04-10
 

--- a/astrid-sys/wit/astrid-capsule.wit
+++ b/astrid-sys/wit/astrid-capsule.wit
@@ -411,6 +411,23 @@ interface ipc {
     /// is automatically propagated from the caller context.
     ipc-publish: func(topic: string, payload: string) -> result<_, string>;
 
+    /// Publish a message on behalf of a specific principal.
+    ///
+    /// Like `ipc-publish` but stamps the outgoing envelope with the
+    /// supplied principal instead of the capsule's own — used by
+    /// uplinks (CLI proxy, Telegram bridge, etc.) to relay messages
+    /// from external clients while preserving the calling identity
+    /// for downstream capability checks. Gated on `uplink = true` in
+    /// the manifest's `[capabilities]` block. The trust model is
+    /// "trust the uplink": the kernel does not verify that the uplink
+    /// actually authenticated the claimed principal. Real cross-
+    /// principal auth lives in issue #658.
+    ipc-publish-as: func(
+        topic: string,
+        payload: string,
+        principal: string,
+    ) -> result<_, string>;
+
     /// Subscribe to a topic pattern and receive a handle.
     ///
     /// Supports exact matches and trailing-suffix wildcards (`foo.bar.*`).

--- a/scripts/sync-host-wit.sh
+++ b/scripts/sync-host-wit.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Sync host/astrid-capsule.wit from the canonical unicity-astrid/wit submodule
+# (at contracts/) into the published astrid-sys crate (at astrid-sys/wit/).
+#
+# Why this exists: astrid-sys is published to crates.io. cargo package
+# can only include files inside the crate's directory, so the WIT file
+# has to physically live at astrid-sys/wit/astrid-capsule.wit. The
+# canonical source of truth is contracts/host/astrid-capsule.wit; this
+# script copies it across. CI lint compares the two and fails if they
+# diverge.
+#
+# Usage: scripts/sync-host-wit.sh
+# To verify (no copy):   scripts/sync-host-wit.sh --check
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/contracts/host/astrid-capsule.wit"
+DST="$ROOT/astrid-sys/wit/astrid-capsule.wit"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "sync-host-wit: source not found: $SRC" >&2
+  echo "sync-host-wit: did you forget 'git submodule update --init'?" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--check" ]]; then
+  if ! diff -q "$SRC" "$DST" >/dev/null 2>&1; then
+    echo "sync-host-wit: $DST is out of sync with $SRC" >&2
+    echo "sync-host-wit: run scripts/sync-host-wit.sh to fix" >&2
+    diff "$SRC" "$DST" >&2 || true
+    exit 1
+  fi
+  echo "sync-host-wit: in sync"
+  exit 0
+fi
+
+cp "$SRC" "$DST"
+echo "sync-host-wit: $DST ← $SRC"


### PR DESCRIPTION
## Summary

The host ABI WIT lived as an unsynced copy in three repos (kernel, sdk-rust, sdk-js) with no canonical home. `unicity-astrid/wit#3` made `unicity-astrid/wit` the canonical home (new `host/astrid-capsule.wit` path). This PR wires sdk-rust to consume it.

## Motivation

Cross-repo WIT drift was a real risk and bit me during JS SDK bring-up: the kernel WIT and sdk-rust WIT had silently diverged (the SDK had `ipc-publish-as` from PR #37, the kernel didn't have a host impl for it yet), and a JS-built capsule failed at `Component::from_binary → linker.add_to_linker` time because the interface signature didn't match. With one canonical file and all consumers submoduling from it, CI lint detects drift before it bites.

## Changes

- New `contracts/` submodule pointing at `unicity-astrid/wit` (pinned to the PR-3 merge commit).
- `astrid-sys/wit/astrid-capsule.wit` is now a sync artifact maintained by `scripts/sync-host-wit.sh`. Can't go away entirely because `astrid-sys` publishes to crates.io and `cargo package` only bundles files inside the crate dir — but the submodule is authoritative.
- New CI job (`wit-sync`) runs `scripts/sync-host-wit.sh --check` on every push/PR. Drift between `contracts/host/` and `astrid-sys/wit/` fails CI.

The synced content brings `main` up to the contract level that was on the unmerged `feat/ipc-publish-as` branch (PR #37). The `wit-bindgen`-generated `astrid_sys::astrid::capsule::ipc::ipc_publish_as` binding is now available to guests on main. The Rust SDK wrapper (`astrid_sdk::ipc::publish_as`) is still NOT exposed here — that needs the kernel-side host impl to land first (separate PR on `unicity-astrid/astrid`).

## Companion PRs

- `unicity-astrid/astrid#TBD` — same submodule treatment on the kernel side (branch `feat/canonical-wit-submodule` pushed, PR not yet opened).
- `unicity-astrid/sdk-js` (new repo) — JS SDK consumes `contracts/host/astrid-capsule.wit` directly via the same submodule; no in-tree mirror because npm has no equivalent of the `cargo package` constraint.

## Followups

The Gemini-bot review on PR #37 flagged the symmetric subscribe-side gap: `ipc-message` should carry an `option<string> principal` field so subscribers can see who published. Confirmed as a worthwhile change. Designed and implemented in a separate canonical-WIT + cross-consumer PR after this one lands.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `scripts/sync-host-wit.sh --check` — passes (in sync at the bumped submodule commit).
- [x] Visual diff between `contracts/host/astrid-capsule.wit` and the synced `astrid-sys/wit/astrid-capsule.wit` — byte-identical.