### PR TITLE
feat(sdk): surface publisher principal on ipc::Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Added
+
+- **`Message::principal: Option<String>`** on `astrid_sdk::ipc::Message`. Surfaces the publisher's principal per-message so subscribers processing multi-message `recv` batches can route / log / authorize correctly without relying on the invocation-context shortcut (which only reflects the first message's publisher — see kernel PR #735). Populated by the host based on caller context for `ipc-publish` and the claimed principal for `ipc-publish-as`. `None` for system events with no attributable principal and for legacy messages. Canonical WIT change: `unicity-astrid/wit#4`; kernel-side host stamping ships in a separate follow-up PR.
+
+- **`#[non_exhaustive]` on `astrid_sdk::ipc::Message`.** Future field additions to the IPC envelope won't break consumers doing exhaustive struct destructuring (`let Message { topic, payload, .. } = msg;` continues to work; `let Message { topic, payload, source_id, principal } = msg;` does not — use `..` instead). Reading individual fields is unaffected. The SDK is the only legitimate publisher of `Message`; direct construction outside the crate is no longer supported. No known external consumers today.
+
 ## [0.6.1] - 2026-05-19
 
 ### Added

--- a/astrid-sdk/src/lib.rs
+++ b/astrid-sdk/src/lib.rs
@@ -195,7 +195,13 @@ pub mod ipc {
     }
 
     /// A message received from the IPC bus.
+    ///
+    /// Marked `#[non_exhaustive]` so future field additions don't break
+    /// downstream code that exhaustively destructures the struct. Read
+    /// individual fields freely; construct via the SDK rather than
+    /// directly (the SDK is the only legitimate publisher).
     #[derive(Debug, Clone)]
+    #[non_exhaustive]
     pub struct Message {
         /// The topic this message was published on.
         pub topic: String,
@@ -203,6 +209,19 @@ pub mod ipc {
         pub payload: String,
         /// UUID of the capsule that published this message.
         pub source_id: String,
+        /// Principal attributed to the publisher of this message.
+        ///
+        /// For messages published via [`publish`], this is the publishing
+        /// capsule's invocation principal. For messages published via
+        /// [`publish_as`], this is the principal the uplink claimed.
+        ///
+        /// `None` for system / kernel-originated events that have no
+        /// attributable principal, and for legacy messages that predate
+        /// this field. Subscribers processing multi-message batches
+        /// (`PollResult::messages`) should read this per-message rather
+        /// than relying on [`crate::runtime::caller`], which only reflects
+        /// the first message's publisher.
+        pub principal: Option<String>,
     }
 
     /// Result of polling or receiving from an IPC subscription.
@@ -239,6 +258,7 @@ pub mod ipc {
                     topic: m.topic,
                     payload: m.payload,
                     source_id: m.source_id,
+                    principal: m.principal,
                 })
                 .collect(),
             dropped: envelope.dropped,


### PR DESCRIPTION
## Summary

Adds the receive-side half of the `ipc-publish-as` feature. Canonical WIT PR `unicity-astrid/wit#4` added `principal: option<string>` to the `ipc-message` record; this PR consumes it.

## Motivation

`unicity-astrid/astrid#735` installs an invocation context from the **first** message of an `ipc::recv` batch — host calls the subscriber makes after recv attribute to that publisher. Covers single-message subscribers. Breaks down for multi-message batches where messages 1..N may have different publishers: the subscriber sees msg[0]'s principal as the invocation context for all of them.

Surfacing `principal` per-message lets subscribers route / log / authorize correctly without relying on that invocation-context shortcut.

## Changes

- Bumps `contracts/` submodule to `unicity-astrid/wit#4`'s merge commit.
- Re-runs `scripts/sync-host-wit.sh` — `astrid-sys/wit/astrid-capsule.wit` picks up the new field. The `wit-bindgen`-generated `astrid_sys::astrid::capsule::ipc::IpcMessage` now carries `principal: Option<String>`.
- Surfaces the field on the SDK's `astrid_sdk::ipc::Message` struct, with docstring describing the `Some`/`None` semantics.
- `envelope_to_poll_result` plumbs the new field from the WIT envelope through to the user-facing `PollResult`.

Until the kernel publish path stamps the field (separate follow-up PR on `unicity-astrid/astrid`), the field is `None` at runtime for every message — contract is now in place and the SDK surface is ready to consume real data the moment the kernel side lands.

## Backward compatibility

`option<string>` by construction. Older guests reading envelopes from a newer kernel ignore the field; newer guests see it. Record evolution under the wasmtime component model handles the rest.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `scripts/sync-host-wit.sh --check` — passes.
- [x] Rebased onto 0.6.1's tip; no test regressions.