### PR TITLE
feat(sdk,net): full std::net::TcpStream surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Added
+
+- **`astrid_sdk::net::connect(host, port)` + `astrid_sdk::net::TcpStream`** — outbound TCP. `connect` is the low-level call returning a `StreamHandle`, parallel to the existing `accept`. `TcpStream` is the `std::net::TcpStream`-shaped facade with `std::io::Read + Write` impls and RAII close-on-drop; user code generally writes `TcpStream::connect("host:port")`. Underlying ABI is the new `astrid:capsule/net.net-connect-tcp` host fn ([wit#5](https://github.com/unicity-astrid/wit/pull/5)); capability-gated against a per-capsule `net_connect` allowlist in `Capsule.toml` (kernel-side, separate PR). SSRF airlock runs on the resolved IP, matching the gate on `http-request`. Unblocks WebSocket, MQTT, Discord/Telegram, postgres/redis, etc. Tracking issue: [astrid#745](https://github.com/unicity-astrid/astrid/issues/745). RFC: [rfcs#27](https://github.com/unicity-astrid/rfcs/pull/27).
+
 ## [0.6.1] - 2026-05-19
 
 ### Added

--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -153,3 +153,147 @@ pub fn send(stream: &StreamHandle, data: &[u8]) -> Result<(), SendError> {
 pub fn close(stream: &StreamHandle) -> Result<(), SysError> {
     wit_net::net_close_stream(stream.0).map_err(SysError::HostError)
 }
+
+/// Open an outbound TCP connection to `host:port` and return a stream handle.
+///
+/// The capsule's `Capsule.toml` must declare a `net_connect` allowlist entry
+/// matching `host:port` (exact `"host:port"` or `"host:*"`); missing or empty
+/// allowlist denies all outbound TCP. The kernel runs the same SSRF airlock
+/// used by `http-request` on the resolved IP and enforces a connect timeout
+/// (10s default).
+///
+/// The returned handle flows through the same [`send`] / [`recv`] / [`try_recv`]
+/// / [`close`] surface as a handle from [`accept`]. For a `std::net::TcpStream`-
+/// shaped facade with [`std::io::Read`] / [`std::io::Write`], see [`TcpStream`].
+pub fn connect(host: &str, port: u16) -> Result<StreamHandle, SysError> {
+    let handle = wit_net::net_connect_tcp(host, port).map_err(SysError::HostError)?;
+    Ok(StreamHandle(handle))
+}
+
+/// A connected TCP stream — the SDK analogue of [`std::net::TcpStream`].
+///
+/// Owns a [`StreamHandle`] from [`connect`] (or [`accept`]) and implements
+/// [`std::io::Read`] and [`std::io::Write`] so generic code that operates on
+/// any `Read + Write` (TLS clients, WebSocket libraries, Postgres drivers)
+/// works unmodified.
+///
+/// The host closes the underlying stream when this value is dropped, so
+/// `TcpStream` is RAII — no explicit close required.
+///
+/// # Example
+///
+/// ```no_run
+/// use astrid_sdk::net::TcpStream;
+/// use std::io::{Read, Write};
+///
+/// let mut sock = TcpStream::connect("fulcrum.unicity.network:443")?;
+/// sock.write_all(b"hello")?;
+///
+/// let mut buf = vec![0u8; 4096];
+/// let n = sock.read(&mut buf)?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct TcpStream {
+    handle: StreamHandle,
+    /// Per-stream read buffer for the byte-stream [`std::io::Read`] facade.
+    /// The host-side frame may be larger than the caller's `read` buffer;
+    /// the surplus stays here until the next call consumes it.
+    read_residual: Vec<u8>,
+}
+
+impl TcpStream {
+    /// Open a TCP connection to `addr`, formatted as `"host:port"`.
+    ///
+    /// DNS resolution and the SSRF airlock run host-side; the WASM guest
+    /// only sees the parsed host and port.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`std::io::Error`] wrapping the host-side failure
+    /// (capability denial, SSRF rejection, DNS failure, connect timeout,
+    /// or remote refusal).
+    pub fn connect<A: AsRef<str>>(addr: A) -> std::io::Result<Self> {
+        let (host, port) = parse_host_port(addr.as_ref())?;
+        let handle = connect(host, port).map_err(io_error_from_sys)?;
+        Ok(Self { handle, read_residual: Vec::new() })
+    }
+
+    /// Wrap an existing [`StreamHandle`] (e.g. one returned by [`accept`])
+    /// in the `TcpStream` facade. The `TcpStream` takes ownership and will
+    /// close the handle on drop.
+    #[must_use]
+    pub fn from_handle(handle: StreamHandle) -> Self {
+        Self { handle, read_residual: Vec::new() }
+    }
+
+    /// The raw stream handle. Use [`send`] / [`recv`] directly if you need
+    /// the frame-oriented API instead of `Read + Write`.
+    #[must_use]
+    pub fn handle(&self) -> &StreamHandle {
+        &self.handle
+    }
+}
+
+impl std::io::Read for TcpStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if !self.read_residual.is_empty() {
+            let n = buf.len().min(self.read_residual.len());
+            buf[..n].copy_from_slice(&self.read_residual[..n]);
+            self.read_residual.drain(..n);
+            return Ok(n);
+        }
+        match recv(&self.handle) {
+            Ok(frame) => {
+                let n = buf.len().min(frame.len());
+                buf[..n].copy_from_slice(&frame[..n]);
+                if n < frame.len() {
+                    self.read_residual = frame[n..].to_vec();
+                }
+                Ok(n)
+            }
+            // Peer disconnect is EOF in the std Read contract.
+            Err(RecvError) => Ok(0),
+        }
+    }
+}
+
+impl std::io::Write for TcpStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        send(&self.handle, buf).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stream closed")
+        })?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // The host writes are non-buffered at the SDK layer.
+        Ok(())
+    }
+}
+
+impl Drop for TcpStream {
+    fn drop(&mut self) {
+        let _ = close(&self.handle);
+    }
+}
+
+fn parse_host_port(addr: &str) -> std::io::Result<(&str, u16)> {
+    let (host, port_str) = addr.rsplit_once(':').ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "address must be \"host:port\"",
+        )
+    })?;
+    let port = port_str.parse::<u16>().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid port: {e}"),
+        )
+    })?;
+    Ok((host, port))
+}
+
+fn io_error_from_sys(err: SysError) -> std::io::Error {
+    std::io::Error::other(err.to_string())
+}

--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -239,12 +239,28 @@ pub fn nodelay(stream: &StreamHandle) -> Result<bool, SysError> {
     wit_net::net_nodelay(stream.0).map_err(SysError::HostError)
 }
 
-/// Set the read timeout. `None` clears it.
+/// Validate + convert a timeout to milliseconds for the host fn.
+///
+/// Mirrors `std::net::TcpStream::set_read_timeout` /
+/// `set_write_timeout`, which both reject `Some(Duration::ZERO)` —
+/// zero would be ambiguous with "no timeout".
+fn to_host_timeout(timeout: Option<std::time::Duration>) -> Result<Option<u64>, SysError> {
+    match timeout {
+        Some(d) if d.is_zero() => Err(SysError::HostError(
+            "timeout must be non-zero (use None to clear)".into(),
+        )),
+        Some(d) => Ok(Some(u64::try_from(d.as_millis()).unwrap_or(u64::MAX))),
+        None => Ok(None),
+    }
+}
+
+/// Set the read timeout. `None` clears it; `Some(Duration::ZERO)` is
+/// rejected (matches `std::net::TcpStream::set_read_timeout`).
 pub fn set_read_timeout(
     stream: &StreamHandle,
     timeout: Option<std::time::Duration>,
 ) -> Result<(), SysError> {
-    let ms = timeout.map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    let ms = to_host_timeout(timeout)?;
     wit_net::net_set_read_timeout(stream.0, ms).map_err(SysError::HostError)
 }
 
@@ -255,12 +271,13 @@ pub fn read_timeout(stream: &StreamHandle) -> Result<Option<std::time::Duration>
         .map(std::time::Duration::from_millis))
 }
 
-/// Set the write timeout. `None` clears it.
+/// Set the write timeout. `None` clears it; `Some(Duration::ZERO)` is
+/// rejected (matches `std::net::TcpStream::set_write_timeout`).
 pub fn set_write_timeout(
     stream: &StreamHandle,
     timeout: Option<std::time::Duration>,
 ) -> Result<(), SysError> {
-    let ms = timeout.map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    let ms = to_host_timeout(timeout)?;
     wit_net::net_set_write_timeout(stream.0, ms).map_err(SysError::HostError)
 }
 
@@ -398,10 +415,13 @@ impl TcpStream {
     }
 
     /// Peek up to `buf.len()` bytes without consuming them. Returns the
-    /// number of bytes written into `buf`.
+    /// number of bytes written into `buf`. `Ok(0)` is EOF (matches
+    /// `std::net::TcpStream::peek`). If a read timeout is set and it
+    /// expires with no data, returns
+    /// [`std::io::ErrorKind::WouldBlock`].
     pub fn peek(&self, buf: &mut [u8]) -> std::io::Result<usize> {
         let max = u32::try_from(buf.len()).unwrap_or(u32::MAX);
-        let bytes = peek(&self.handle, max).map_err(io_error_from_sys)?;
+        let bytes = peek(&self.handle, max).map_err(io_error_from_net_op)?;
         let n = buf.len().min(bytes.len());
         buf[..n].copy_from_slice(&bytes[..n]);
         Ok(n)
@@ -411,7 +431,7 @@ impl TcpStream {
 impl std::io::Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let max = u32::try_from(buf.len()).unwrap_or(u32::MAX);
-        let bytes = read_bytes(&self.handle, max).map_err(io_error_from_sys)?;
+        let bytes = read_bytes(&self.handle, max).map_err(io_error_from_net_op)?;
         let n = buf.len().min(bytes.len());
         buf[..n].copy_from_slice(&bytes[..n]);
         Ok(n)
@@ -420,7 +440,7 @@ impl std::io::Read for TcpStream {
 
 impl std::io::Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let n = write_bytes(&self.handle, buf).map_err(io_error_from_sys)?;
+        let n = write_bytes(&self.handle, buf).map_err(io_error_from_net_op)?;
         Ok(n as usize)
     }
 
@@ -436,22 +456,128 @@ impl Drop for TcpStream {
     }
 }
 
+/// Parse `"host:port"` for [`TcpStream::connect`]. Strips IPv6 square
+/// brackets — `[::1]:443` → `("::1", 443)` — because the host fn takes
+/// a raw hostname/IP without brackets (matching `tokio::net::lookup_host`
+/// and `std`'s `(&str, u16)` `ToSocketAddrs` impl).
 fn parse_host_port(addr: &str) -> std::io::Result<(&str, u16)> {
+    // IPv6 literal in `[v6]:port` form — split on the closing bracket
+    // so a v6 address with internal colons doesn't fool `rsplit_once`.
+    if let Some(end) = addr.strip_prefix('[') {
+        let (v6, rest) = end.split_once(']').ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "missing closing `]` in IPv6 address",
+            )
+        })?;
+        let port_str = rest.strip_prefix(':').ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "IPv6 address must be followed by `:port`",
+            )
+        })?;
+        let port = parse_port(port_str)?;
+        return Ok((v6, port));
+    }
     let (host, port_str) = addr.rsplit_once(':').ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "address must be \"host:port\"",
         )
     })?;
-    let port = port_str.parse::<u16>().map_err(|e| {
+    Ok((host, parse_port(port_str)?))
+}
+
+fn parse_port(port_str: &str) -> std::io::Result<u16> {
+    port_str.parse::<u16>().map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("invalid port: {e}"),
         )
-    })?;
-    Ok((host, port))
+    })
 }
 
 fn io_error_from_sys(err: SysError) -> std::io::Error {
     std::io::Error::other(err.to_string())
+}
+
+/// `io::Error` from a network-op `SysError`, mapping the host's
+/// `"... would block"` sentinel to [`std::io::ErrorKind::WouldBlock`]
+/// so std-style callers (`Read::read`, `Write::write`, `peek`) can
+/// distinguish "timeout fired, retry" from a real EOF or transport
+/// error.
+fn io_error_from_net_op(err: SysError) -> std::io::Error {
+    let msg = err.to_string();
+    if msg.contains("would block") {
+        std::io::Error::new(std::io::ErrorKind::WouldBlock, msg)
+    } else {
+        std::io::Error::other(msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_host_port_basic() {
+        let (h, p) = parse_host_port("example.com:443").unwrap();
+        assert_eq!((h, p), ("example.com", 443));
+    }
+
+    #[test]
+    fn parse_host_port_strips_ipv6_brackets() {
+        let (h, p) = parse_host_port("[::1]:443").unwrap();
+        assert_eq!((h, p), ("::1", 443));
+        let (h, p) = parse_host_port("[2001:db8::1]:8080").unwrap();
+        assert_eq!((h, p), ("2001:db8::1", 8080));
+    }
+
+    #[test]
+    fn parse_host_port_ipv6_without_brackets_fails_cleanly() {
+        // `2001:db8::1:443` is ambiguous (no brackets, multiple colons).
+        // rsplit_once takes the last colon — the port parse then fails
+        // because `:1` precedes it. We accept this; brackets are the
+        // unambiguous form.
+        assert!(parse_host_port("2001:db8::1:abc").is_err());
+    }
+
+    #[test]
+    fn parse_host_port_missing_close_bracket() {
+        assert!(parse_host_port("[::1:443").is_err());
+    }
+
+    #[test]
+    fn parse_host_port_invalid_port_rejected() {
+        assert!(parse_host_port("example.com:notaport").is_err());
+        assert!(parse_host_port("example.com:99999").is_err()); // exceeds u16
+    }
+
+    #[test]
+    fn to_host_timeout_rejects_zero() {
+        let err = to_host_timeout(Some(std::time::Duration::ZERO)).unwrap_err();
+        assert!(err.to_string().contains("non-zero"));
+    }
+
+    #[test]
+    fn to_host_timeout_passes_through() {
+        assert_eq!(to_host_timeout(None).unwrap(), None);
+        assert_eq!(
+            to_host_timeout(Some(std::time::Duration::from_millis(500)))
+                .unwrap(),
+            Some(500)
+        );
+    }
+
+    #[test]
+    fn io_error_from_net_op_maps_would_block() {
+        let err = io_error_from_net_op(SysError::HostError("read would block".into()));
+        assert_eq!(err.kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn io_error_from_net_op_other_passes_through() {
+        let err = io_error_from_net_op(SysError::HostError("dns: no addresses".into()));
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    }
 }

--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -154,6 +154,22 @@ pub fn close(stream: &StreamHandle) -> Result<(), SysError> {
     wit_net::net_close_stream(stream.0).map_err(SysError::HostError)
 }
 
+// ---------------------------------------------------------------------------
+// Outbound TCP — std::net::TcpStream parity
+// ---------------------------------------------------------------------------
+
+/// Direction argument for [`TcpStream::shutdown`] — mirror of
+/// [`std::net::Shutdown`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shutdown {
+    /// Half-close the read side.
+    Read,
+    /// Half-close the write side.
+    Write,
+    /// Close both directions.
+    Both,
+}
+
 /// Open an outbound TCP connection to `host:port` and return a stream handle.
 ///
 /// The capsule's `Capsule.toml` must declare a `net_connect` allowlist entry
@@ -162,20 +178,116 @@ pub fn close(stream: &StreamHandle) -> Result<(), SysError> {
 /// used by `http-request` on the resolved IP and enforces a connect timeout
 /// (10s default).
 ///
-/// The returned handle flows through the same [`send`] / [`recv`] / [`try_recv`]
-/// / [`close`] surface as a handle from [`accept`]. For a `std::net::TcpStream`-
-/// shaped facade with [`std::io::Read`] / [`std::io::Write`], see [`TcpStream`].
+/// The returned handle flows through the byte-stream surface
+/// ([`read_bytes`] / [`write_bytes`] / [`close`]) and the std-shaped
+/// [`TcpStream`] facade. The frame-oriented [`recv`] / [`send`] also work
+/// but are intended for the inbound Unix-accept proxy use case.
 pub fn connect(host: &str, port: u16) -> Result<StreamHandle, SysError> {
     let handle = wit_net::net_connect_tcp(host, port).map_err(SysError::HostError)?;
     Ok(StreamHandle(handle))
 }
 
+/// Read up to `max_bytes` from `stream` without length-prefix framing.
+///
+/// Mirrors `std::io::Read::read`. Empty result means EOF (peer
+/// disconnected). Honours any read timeout previously set via
+/// [`set_read_timeout`].
+pub fn read_bytes(stream: &StreamHandle, max_bytes: u32) -> Result<Vec<u8>, SysError> {
+    wit_net::net_read_bytes(stream.0, max_bytes).map_err(SysError::HostError)
+}
+
+/// Write `data` to `stream` without framing. Returns the number of bytes
+/// actually written (may be less than `data.len()`). Honours any write
+/// timeout previously set via [`set_write_timeout`].
+pub fn write_bytes(stream: &StreamHandle, data: &[u8]) -> Result<u32, SysError> {
+    wit_net::net_write_bytes(stream.0, data).map_err(SysError::HostError)
+}
+
+/// Peek up to `max_bytes` without consuming them — the next
+/// [`read_bytes`] returns the same data again.
+pub fn peek(stream: &StreamHandle, max_bytes: u32) -> Result<Vec<u8>, SysError> {
+    wit_net::net_peek(stream.0, max_bytes).map_err(SysError::HostError)
+}
+
+/// Half-close the read side, write side, or both.
+pub fn shutdown(stream: &StreamHandle, how: Shutdown) -> Result<(), SysError> {
+    let wit_how = match how {
+        Shutdown::Read => wit_types::ShutdownHow::Read,
+        Shutdown::Write => wit_types::ShutdownHow::Write,
+        Shutdown::Both => wit_types::ShutdownHow::Both,
+    };
+    wit_net::net_shutdown(stream.0, wit_how).map_err(SysError::HostError)
+}
+
+/// Remote peer address, formatted as `"ip:port"`.
+pub fn peer_addr(stream: &StreamHandle) -> Result<String, SysError> {
+    wit_net::net_peer_addr(stream.0).map_err(SysError::HostError)
+}
+
+/// Local socket address, formatted as `"ip:port"`.
+pub fn local_addr(stream: &StreamHandle) -> Result<String, SysError> {
+    wit_net::net_local_addr(stream.0).map_err(SysError::HostError)
+}
+
+/// Toggle `TCP_NODELAY` (Nagle off when `true`).
+pub fn set_nodelay(stream: &StreamHandle, nodelay: bool) -> Result<(), SysError> {
+    wit_net::net_set_nodelay(stream.0, nodelay).map_err(SysError::HostError)
+}
+
+/// Current `TCP_NODELAY` setting.
+pub fn nodelay(stream: &StreamHandle) -> Result<bool, SysError> {
+    wit_net::net_nodelay(stream.0).map_err(SysError::HostError)
+}
+
+/// Set the read timeout. `None` clears it.
+pub fn set_read_timeout(
+    stream: &StreamHandle,
+    timeout: Option<std::time::Duration>,
+) -> Result<(), SysError> {
+    let ms = timeout.map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    wit_net::net_set_read_timeout(stream.0, ms).map_err(SysError::HostError)
+}
+
+/// Current read timeout, or `None` if unset.
+pub fn read_timeout(stream: &StreamHandle) -> Result<Option<std::time::Duration>, SysError> {
+    Ok(wit_net::net_read_timeout(stream.0)
+        .map_err(SysError::HostError)?
+        .map(std::time::Duration::from_millis))
+}
+
+/// Set the write timeout. `None` clears it.
+pub fn set_write_timeout(
+    stream: &StreamHandle,
+    timeout: Option<std::time::Duration>,
+) -> Result<(), SysError> {
+    let ms = timeout.map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    wit_net::net_set_write_timeout(stream.0, ms).map_err(SysError::HostError)
+}
+
+/// Current write timeout, or `None` if unset.
+pub fn write_timeout(stream: &StreamHandle) -> Result<Option<std::time::Duration>, SysError> {
+    Ok(wit_net::net_write_timeout(stream.0)
+        .map_err(SysError::HostError)?
+        .map(std::time::Duration::from_millis))
+}
+
+/// Set the IP TTL on outgoing packets.
+pub fn set_ttl(stream: &StreamHandle, ttl: u32) -> Result<(), SysError> {
+    wit_net::net_set_ttl(stream.0, ttl).map_err(SysError::HostError)
+}
+
+/// Current IP TTL.
+pub fn ttl(stream: &StreamHandle) -> Result<u32, SysError> {
+    wit_net::net_ttl(stream.0).map_err(SysError::HostError)
+}
+
 /// A connected TCP stream — the SDK analogue of [`std::net::TcpStream`].
 ///
-/// Owns a [`StreamHandle`] from [`connect`] (or [`accept`]) and implements
-/// [`std::io::Read`] and [`std::io::Write`] so generic code that operates on
-/// any `Read + Write` (TLS clients, WebSocket libraries, Postgres drivers)
-/// works unmodified.
+/// Owns a [`StreamHandle`] from [`connect`] and implements
+/// [`std::io::Read`] and [`std::io::Write`] over the host's byte-stream
+/// `net-read-bytes` / `net-write-bytes` (no length-prefix framing). Generic
+/// code that operates on any `Read + Write` (TLS clients, WebSocket
+/// libraries, Postgres drivers) works unmodified.
 ///
 /// The host closes the underlying stream when this value is dropped, so
 /// `TcpStream` is RAII — no explicit close required.
@@ -187,7 +299,8 @@ pub fn connect(host: &str, port: u16) -> Result<StreamHandle, SysError> {
 /// use std::io::{Read, Write};
 ///
 /// let mut sock = TcpStream::connect("fulcrum.unicity.network:443")?;
-/// sock.write_all(b"hello")?;
+/// sock.set_nodelay(true)?;
+/// sock.write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")?;
 ///
 /// let mut buf = vec![0u8; 4096];
 /// let n = sock.read(&mut buf)?;
@@ -196,10 +309,6 @@ pub fn connect(host: &str, port: u16) -> Result<StreamHandle, SysError> {
 #[derive(Debug)]
 pub struct TcpStream {
     handle: StreamHandle,
-    /// Per-stream read buffer for the byte-stream [`std::io::Read`] facade.
-    /// The host-side frame may be larger than the caller's `read` buffer;
-    /// the surplus stays here until the next call consumes it.
-    read_residual: Vec<u8>,
 }
 
 impl TcpStream {
@@ -216,54 +325,103 @@ impl TcpStream {
     pub fn connect<A: AsRef<str>>(addr: A) -> std::io::Result<Self> {
         let (host, port) = parse_host_port(addr.as_ref())?;
         let handle = connect(host, port).map_err(io_error_from_sys)?;
-        Ok(Self { handle, read_residual: Vec::new() })
+        Ok(Self { handle })
     }
 
-    /// Wrap an existing [`StreamHandle`] (e.g. one returned by [`accept`])
-    /// in the `TcpStream` facade. The `TcpStream` takes ownership and will
-    /// close the handle on drop.
+    /// Wrap an existing [`StreamHandle`] in the `TcpStream` facade. The
+    /// `TcpStream` takes ownership and will close the handle on drop.
     #[must_use]
     pub fn from_handle(handle: StreamHandle) -> Self {
-        Self { handle, read_residual: Vec::new() }
+        Self { handle }
     }
 
-    /// The raw stream handle. Use [`send`] / [`recv`] directly if you need
-    /// the frame-oriented API instead of `Read + Write`.
+    /// The raw stream handle. Use the free functions in this module if you
+    /// need the byte-stream surface directly.
     #[must_use]
     pub fn handle(&self) -> &StreamHandle {
         &self.handle
+    }
+
+    /// Set the `TCP_NODELAY` socket option (Nagle's algorithm off when `true`).
+    pub fn set_nodelay(&self, nodelay: bool) -> std::io::Result<()> {
+        set_nodelay(&self.handle, nodelay).map_err(io_error_from_sys)
+    }
+
+    /// Read the current `TCP_NODELAY` setting.
+    pub fn nodelay(&self) -> std::io::Result<bool> {
+        nodelay(&self.handle).map_err(io_error_from_sys)
+    }
+
+    /// Set the read timeout. `None` clears it.
+    pub fn set_read_timeout(&self, timeout: Option<std::time::Duration>) -> std::io::Result<()> {
+        set_read_timeout(&self.handle, timeout).map_err(io_error_from_sys)
+    }
+
+    /// Current read timeout.
+    pub fn read_timeout(&self) -> std::io::Result<Option<std::time::Duration>> {
+        read_timeout(&self.handle).map_err(io_error_from_sys)
+    }
+
+    /// Set the write timeout. `None` clears it.
+    pub fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> std::io::Result<()> {
+        set_write_timeout(&self.handle, timeout).map_err(io_error_from_sys)
+    }
+
+    /// Current write timeout.
+    pub fn write_timeout(&self) -> std::io::Result<Option<std::time::Duration>> {
+        write_timeout(&self.handle).map_err(io_error_from_sys)
+    }
+
+    /// Set the IP `TTL` on outgoing packets.
+    pub fn set_ttl(&self, ttl_val: u32) -> std::io::Result<()> {
+        set_ttl(&self.handle, ttl_val).map_err(io_error_from_sys)
+    }
+
+    /// Current IP `TTL`.
+    pub fn ttl(&self) -> std::io::Result<u32> {
+        ttl(&self.handle).map_err(io_error_from_sys)
+    }
+
+    /// Remote peer address as `"ip:port"`.
+    pub fn peer_addr(&self) -> std::io::Result<String> {
+        peer_addr(&self.handle).map_err(io_error_from_sys)
+    }
+
+    /// Local socket address as `"ip:port"`.
+    pub fn local_addr(&self) -> std::io::Result<String> {
+        local_addr(&self.handle).map_err(io_error_from_sys)
+    }
+
+    /// Half-close the read side, write side, or both.
+    pub fn shutdown(&self, how: Shutdown) -> std::io::Result<()> {
+        shutdown(&self.handle, how).map_err(io_error_from_sys)
+    }
+
+    /// Peek up to `buf.len()` bytes without consuming them. Returns the
+    /// number of bytes written into `buf`.
+    pub fn peek(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let max = u32::try_from(buf.len()).unwrap_or(u32::MAX);
+        let bytes = peek(&self.handle, max).map_err(io_error_from_sys)?;
+        let n = buf.len().min(bytes.len());
+        buf[..n].copy_from_slice(&bytes[..n]);
+        Ok(n)
     }
 }
 
 impl std::io::Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if !self.read_residual.is_empty() {
-            let n = buf.len().min(self.read_residual.len());
-            buf[..n].copy_from_slice(&self.read_residual[..n]);
-            self.read_residual.drain(..n);
-            return Ok(n);
-        }
-        match recv(&self.handle) {
-            Ok(frame) => {
-                let n = buf.len().min(frame.len());
-                buf[..n].copy_from_slice(&frame[..n]);
-                if n < frame.len() {
-                    self.read_residual = frame[n..].to_vec();
-                }
-                Ok(n)
-            }
-            // Peer disconnect is EOF in the std Read contract.
-            Err(RecvError) => Ok(0),
-        }
+        let max = u32::try_from(buf.len()).unwrap_or(u32::MAX);
+        let bytes = read_bytes(&self.handle, max).map_err(io_error_from_sys)?;
+        let n = buf.len().min(bytes.len());
+        buf[..n].copy_from_slice(&bytes[..n]);
+        Ok(n)
     }
 }
 
 impl std::io::Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        send(&self.handle, buf).map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stream closed")
-        })?;
-        Ok(buf.len())
+        let n = write_bytes(&self.handle, buf).map_err(io_error_from_sys)?;
+        Ok(n as usize)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -563,8 +563,7 @@ mod tests {
     fn to_host_timeout_passes_through() {
         assert_eq!(to_host_timeout(None).unwrap(), None);
         assert_eq!(
-            to_host_timeout(Some(std::time::Duration::from_millis(500)))
-                .unwrap(),
+            to_host_timeout(Some(std::time::Duration::from_millis(500))).unwrap(),
             Some(500)
         );
     }

--- a/astrid-sys/wit/astrid-capsule.wit
+++ b/astrid-sys/wit/astrid-capsule.wit
@@ -569,6 +569,29 @@ interface net {
     /// Idempotent: closing an already-closed handle is a no-op.
     /// Publishes a `client.v1.disconnect` IPC event.
     net-close-stream: func(stream-handle: u64) -> result<_, string>;
+
+    /// Open an outbound TCP connection to `host:port`.
+    ///
+    /// Returns a stream handle compatible with the existing
+    /// `net-read` / `net-write` / `net-close-stream` functions
+    /// — the same handle type returned by `net-accept`.
+    ///
+    /// Security gates (all checked before any TCP syscall):
+    /// - The capsule's `net_connect` capability allowlist must
+    ///   contain a pattern matching `host:port`. Patterns are
+    ///   `"host:port"` exact matches or `"host:*"` (any port for
+    ///   the named host). Missing or empty allowlist denies all
+    ///   outbound TCP (fail-closed).
+    /// - DNS resolution runs after the capability check. The
+    ///   resolved IP is rejected if it falls into a private,
+    ///   loopback, link-local, multicast, or unspecified range,
+    ///   matching the airlock that gates `http-request` /
+    ///   `http-stream-start`.
+    /// - The capsule's per-instance active-stream cap (default
+    ///   8, shared with `net-accept`) is enforced.
+    /// - Connect attempts time out (default 10s) rather than
+    ///   holding the WASM guest in a host fn indefinitely.
+    net-connect-tcp: func(host: string, port: u16) -> result<u64, string>;
 }
 
 /// HTTP client operations with SSRF protection.

--- a/astrid-sys/wit/astrid-capsule.wit
+++ b/astrid-sys/wit/astrid-capsule.wit
@@ -352,6 +352,20 @@ interface types {
         /// Whether the action was approved.
         approved: bool,
     }
+
+    /// Direction argument for `net-shutdown` — mirrors `std::net::Shutdown`.
+    enum shutdown-how {
+        /// Half-close the read side. Subsequent reads return EOF; writes
+        /// continue.
+        read,
+        /// Half-close the write side. The peer sees EOF on its read side;
+        /// reads continue.
+        write,
+        /// Close both directions. Equivalent to `net-close-stream` except
+        /// the handle entry is retained so getters (`peer-addr`, etc.)
+        /// still work until the explicit close call.
+        both,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -531,7 +545,7 @@ interface kv {
 ///
 /// Max 8 concurrent streams per capsule.
 interface net {
-    use types.{net-read-status};
+    use types.{net-read-status, shutdown-how};
 
     /// Bind and activate the pre-provisioned Unix socket listener.
     ///
@@ -592,6 +606,99 @@ interface net {
     /// - Connect attempts time out (default 10s) rather than
     ///   holding the WASM guest in a host fn indefinitely.
     net-connect-tcp: func(host: string, port: u16) -> result<u64, string>;
+
+    /// Read up to `max-bytes` from `stream` without length-prefix framing.
+    ///
+    /// Mirrors `std::net::TcpStream::read` (and `<TcpStream as Read>::read`).
+    /// Returns the bytes that were available — may be shorter than
+    /// `max-bytes`. Empty list means no data is ready under the current
+    /// read timeout (default: non-blocking, ~50 ms internal poll).
+    ///
+    /// Use this for byte-stream protocols (WebSocket, MQTT, postgres,
+    /// HTTP/1.1, TLS, …). The existing `net-read` keeps the length-prefix
+    /// framing required by the uplink-proxy use case.
+    net-read-bytes: func(stream-handle: u64, max-bytes: u32) -> result<list<u8>, string>;
+
+    /// Write `data` to `stream` without length-prefix framing.
+    ///
+    /// Mirrors `<TcpStream as Write>::write`. Returns the number of
+    /// bytes actually written — may be less than `data.len()` when the
+    /// kernel-side socket buffer is full. Callers loop until `data` is
+    /// drained (the SDK `write_all` wrapper handles this).
+    net-write-bytes: func(stream-handle: u64, data: list<u8>) -> result<u32, string>;
+
+    /// Read up to `max-bytes` from `stream` without consuming them.
+    ///
+    /// Mirrors `std::net::TcpStream::peek`. Subsequent `net-read-bytes`
+    /// returns the same bytes again. Useful for protocol detection on
+    /// the first frame of a connection.
+    net-peek: func(stream-handle: u64, max-bytes: u32) -> result<list<u8>, string>;
+
+    /// Shut down the read side, write side, or both halves of `stream`.
+    ///
+    /// Mirrors `std::net::TcpStream::shutdown`. After `shutdown-how::write`
+    /// the peer sees EOF on its read side; further sends on the local
+    /// side return an error. `shutdown-how::both` closes both directions
+    /// but leaves the handle entry intact so accessors (e.g.
+    /// `peer-addr`) still work until `net-close-stream` is called.
+    net-shutdown: func(stream-handle: u64, how: shutdown-how) -> result<_, string>;
+
+    /// Return the remote peer address as `"ip:port"`.
+    ///
+    /// Mirrors `std::net::TcpStream::peer_addr`. Returns an error for
+    /// Unix-domain stream handles.
+    net-peer-addr: func(stream-handle: u64) -> result<string, string>;
+
+    /// Return the local socket address as `"ip:port"`.
+    ///
+    /// Mirrors `std::net::TcpStream::local_addr`. Returns an error for
+    /// Unix-domain stream handles.
+    net-local-addr: func(stream-handle: u64) -> result<string, string>;
+
+    /// Enable or disable the `TCP_NODELAY` option (Nagle's algorithm off
+    /// when `true`).
+    ///
+    /// Mirrors `std::net::TcpStream::set_nodelay`. Returns an error for
+    /// Unix-domain stream handles.
+    net-set-nodelay: func(stream-handle: u64, nodelay: bool) -> result<_, string>;
+
+    /// Return the current `TCP_NODELAY` setting.
+    ///
+    /// Mirrors `std::net::TcpStream::nodelay`.
+    net-nodelay: func(stream-handle: u64) -> result<bool, string>;
+
+    /// Set the read timeout. `none` clears the timeout (reads still
+    /// honour the host's internal cancellation token; this controls
+    /// only the user-visible blocking duration of each `net-read-bytes`
+    /// call).
+    ///
+    /// Mirrors `std::net::TcpStream::set_read_timeout`. Subsequent
+    /// `net-read-bytes` and `net-peek` calls honour the new value.
+    net-set-read-timeout: func(stream-handle: u64, timeout-ms: option<u64>) -> result<_, string>;
+
+    /// Return the current read timeout in milliseconds, or `none` if
+    /// unset.
+    net-read-timeout: func(stream-handle: u64) -> result<option<u64>, string>;
+
+    /// Set the write timeout. `none` clears it.
+    ///
+    /// Mirrors `std::net::TcpStream::set_write_timeout`.
+    net-set-write-timeout: func(stream-handle: u64, timeout-ms: option<u64>) -> result<_, string>;
+
+    /// Return the current write timeout in milliseconds, or `none` if
+    /// unset.
+    net-write-timeout: func(stream-handle: u64) -> result<option<u64>, string>;
+
+    /// Set the IP `TTL` field on outgoing packets.
+    ///
+    /// Mirrors `std::net::TcpStream::set_ttl`. Returns an error for
+    /// Unix-domain stream handles.
+    net-set-ttl: func(stream-handle: u64, ttl: u32) -> result<_, string>;
+
+    /// Return the current IP TTL.
+    ///
+    /// Mirrors `std::net::TcpStream::ttl`.
+    net-ttl: func(stream-handle: u64) -> result<u32, string>;
 }
 
 /// HTTP client operations with SSRF protection.


### PR DESCRIPTION
## Summary

Outbound TCP for capsules. Mirrors `std::net::TcpStream` end-to-end — every method a Rust binary expects on a connected TCP stream is available on the SDK side. WebSocket libraries, TLS wrappers, postgres drivers — anything generic over `Read + Write` — drops in unmodified.

## Added

### Free functions (low-level, one per WIT host fn)

- `connect(host, port) -> StreamHandle` — opens an outbound TCP connection. Capability-gated against `Capsule.toml` `net_connect` allowlist; SSRF airlock on resolved IP; 10s connect timeout.
- `read_bytes(stream, max) -> Vec<u8>` / `write_bytes(stream, data) -> u32` — byte-stream read/write (no length-prefix framing).
- `peek(stream, max) -> Vec<u8>` — non-destructive read.
- `shutdown(stream, Shutdown::{Read,Write,Both})` — half-close. Backed by `socket2::SockRef` for full direction support.
- `peer_addr` / `local_addr` — `ip:port` strings.
- `set_nodelay` / `nodelay` — TCP_NODELAY.
- `set_read_timeout` / `read_timeout` — `Option<Duration>`.
- `set_write_timeout` / `write_timeout`.
- `set_ttl` / `ttl` — IP TTL.

### `TcpStream` facade

`std::net::TcpStream`-shaped wrapper around `StreamHandle` with std::io::Read + Write impls, RAII close-on-drop, and matching inherent methods (`set_nodelay`, `peer_addr`, `shutdown(Shutdown::*)`, `peek`, timeouts, `set_ttl`).

```rust
use astrid_sdk::net::TcpStream;
use std::io::{Read, Write};

let mut sock = TcpStream::connect("fulcrum.unicity.network:443")?;
sock.set_nodelay(true)?;
sock.write_all(b"GET / HTTP/1.1\\r\\nHost: example.com\\r\\n\\r\\n")?;
```

### `Shutdown` enum

Local mirror of `std::net::Shutdown` (Read / Write / Both), wired to the WIT `shutdown-how` enum.

## Submodule

`contracts/` bumped to `feat/net-connect-tcp` tip on canonical [unicity-astrid/wit#5](https://github.com/unicity-astrid/wit/pull/5).

## TLS

Out of scope — std::net::TcpStream doesn't ship TLS either. Capsules that need TLS bring their own crate (`rustls`, etc.) over this byte-stream surface, matching how native Rust binaries do it.

## Refs

- RFC: [unicity-astrid/rfcs#27](https://github.com/unicity-astrid/rfcs/pull/27)
- WIT: [unicity-astrid/wit#5](https://github.com/unicity-astrid/wit/pull/5)
- Tracking issue: [unicity-astrid/astrid#745](https://github.com/unicity-astrid/astrid/issues/745)

## Verification

- `cargo build/test/clippy -p astrid-sdk` clean
- Doctest on `TcpStream` compiles