### PR TITLE
chore: release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-26
+
 ### Breaking
 
 - **Per-domain WIT host ABI.** The single `astrid:capsule@0.1.0` world has been split into per-domain frozen packages at `@1.0.0` (`astrid:fs`, `astrid:ipc`, `astrid:kv`, `astrid:net`, `astrid:http`, `astrid:sys`, `astrid:process`, `astrid:uplink`, `astrid:elicit`, `astrid:approval`, `astrid:identity`) plus Astrid-owned foundation I/O (`astrid:io/{error, poll, streams}`). Capsule authors must recompile against this SDK; the contract surface is wire-level incompatible with pre-0.7 capsules. Guest exports moved to per-export worlds in `astrid:guest@1.0.0` (`interceptor`, `background`, `installable`, `upgradable`).


### PR DESCRIPTION
## Linked Issue

Closes #46

## Summary

Roll `[Unreleased]` into `[0.7.0]` to pair with the merged `unicity-astrid/astrid` 0.7.0 release. Workspace was already bumped 0.6.1 → 0.7.0 in #44 (per-domain WIT migration); this PR is the documentation-side companion.

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `[0.7.0] - 2026-05-26`. No content changes — the section already has the per-domain WIT migration roll-up (Breaking + Added + Changed + Fixed) from when #44 merged.
- No `Cargo.toml` changes — workspace version + internal deps already at 0.7.0.

## Test Plan

- [x] `cargo check --workspace` clean

## Manual

- [ ] Tag `v0.7.0` after merge
- [ ] `cargo workspaces publish --from-git` publishes astrid-sys / astrid-sdk-macros / astrid-sdk in dep order

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
