### PR TITLE
feat(contracts): regenerate bundle with hook-event-request

### DIFF
--- a/astrid-sdk/wit/astrid-contracts.wit
+++ b/astrid-sdk/wit/astrid-contracts.wit
@@ -296,6 +296,27 @@ interface hook {
         /// Merged data from interceptor responses (opaque JSON).
         data: option<string>,
     }
+
+    /// Payload of `hook.v1.event.<hook_name>` envelopes published by the
+    /// hook bridge during fan-out to subscriber capsules.
+    ///
+    /// Subscribers wishing to influence the outcome (merge strategies
+    /// `ToolCallBefore` / `LastNonNull`) reply on the per-request
+    /// scoped topic `hook.v1.response.<hook_name>.<correlation_id>`.
+    /// When `correlation_id` is absent, the dispatch is fire-and-forget
+    /// (merge semantics `None`) and no reply topic exists.
+    record hook-event-request {
+        /// Semantic hook name (e.g. `before_tool_call`, `session_start`,
+        /// `on_compaction_started`). Matches the mapping table in
+        /// `astrid-capsule-hook-bridge`.
+        hook: string,
+        /// Original lifecycle event payload, serialized as JSON. Opaque
+        /// to the bus — subscribers parse based on the hook name.
+        payload: string,
+        /// Per-request correlation id for scoped replies. `none` for
+        /// fire-and-forget hooks.
+        correlation-id: option<string>,
+    }
 }
 
 // ── llm ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Submodule bump + `sync-contracts-wit.sh` regeneration to land
`hook-event-request` in the bundled `astrid-sdk/wit/astrid-contracts.wit`.

## Depends on

unicity-astrid/wit#11 — the record itself is added there. This PR
bumps the submodule pointer to the wit feat branch; once that PR
merges to main, the commit becomes reachable from main.

## Context

Audit of all 18 capsule `Capsule.toml` files surfaced one referential
miss: `astrid-capsule-hook-bridge` references
`@unicity-astrid/wit/hook/hook-event-request`, but the record didn't
exist anywhere in this repo's bundled WIT. Adding it to the bundle
keeps the SDK-side `codegen_wit_events!` output complete, so capsules
that switch from hand-coded structs to generated types get the
correct shape.

## Test plan

- [x] `grep -c hook-event-request astrid-sdk/wit/astrid-contracts.wit`
      returns 1 (the record definition).
- [x] `cargo check --workspace` succeeds.