### PR TITLE
docs(sys): correct random-bytes comment to match the WIT contract

### DIFF
--- a/astrid-sys/src/lib.rs
+++ b/astrid-sys/src/lib.rs
@@ -138,8 +138,10 @@ unsafe extern "Rust" fn __getrandom_v03_custom(
     len: usize,
 ) -> Result<(), getrandom::Error> {
     // Pull bytes from the kernel in chunks bounded by the host fn's
-    // per-call cap. `astrid:sys/host.random-bytes` is audited +
-    // principal-scoped + quota-gated like every other Astrid host fn.
+    // per-call cap. `astrid:sys/host.random-bytes` is served straight
+    // from the host's OS CSPRNG; per the `astrid:sys` WIT contract it is
+    // intentionally ungated and not audited (read-only, no side effects),
+    // unlike the gated/audited host calls such as fs / net / process.
     const CHUNK: usize = 4096;
     let mut written = 0usize;
     while written < len {


### PR DESCRIPTION
## Summary

The getrandom custom-backend comment in `astrid-sys` claimed `astrid:sys/host.random-bytes` is "audited + principal-scoped + quota-gated like every other Astrid host fn." It is not: the `sys` WIT documents `random-bytes` as "Audit: not recorded (read-only, no side effects)" and the host impl performs no capability check, audit emission, or quota accounting.

## Changes

- `astrid-sys/src/lib.rs`: reword the comment to state the bytes come from the host OS CSPRNG and that the call is intentionally ungated/unaudited, unlike the gated/audited fs / net / process host calls.

## Notes

Comment-only correction — no code or behaviour change, not user-facing, so no `CHANGELOG.md` entry. Pairs with unicity-astrid/astrid#799 (host now sources `random-bytes` from `OsRng`).