### PR TITLE
docs(sdk): reference the [subscribe] handler form, not [[interceptor]]

### DIFF
--- a/astrid-sdk/src/interceptors.rs
+++ b/astrid-sdk/src/interceptors.rs
@@ -36,8 +36,8 @@ impl InterceptorBinding {
 /// Query the runtime for auto-subscribed interceptor handles.
 ///
 /// Returns an empty vec if this capsule has no auto-subscribed
-/// interceptors (i.e. it does not have both `run()` and
-/// `[[interceptor]]`). Each entry maps an action name to the IPC
+/// interceptors (i.e. it does not have both `run()` and a `[subscribe]`
+/// entry with a `handler`). Each entry maps an action name to the IPC
 /// topic the kernel routes through `astrid-hook-trigger`.
 pub fn bindings() -> Result<Vec<InterceptorBinding>, SysError> {
     let handles = wit_ipc::get_interceptor_bindings().map_err(host_err)?;

--- a/astrid-sdk/src/lib.rs
+++ b/astrid-sdk/src/lib.rs
@@ -502,8 +502,8 @@ pub mod elicit;
 
 /// Auto-subscribed interceptor bindings for run-loop capsules.
 ///
-/// When a capsule declares both `run()` and `[[interceptor]]`, the runtime
-/// auto-subscribes to each interceptor's topic and delivers events through
+/// When a capsule declares both `run()` and a `[subscribe]` entry with a
+/// `handler`, the runtime auto-subscribes to each interceptor's topic and delivers events through
 /// the IPC channel the run loop already reads from. This module provides
 /// helpers to query the subscription mappings and dispatch events by action.
 pub mod interceptors;


### PR DESCRIPTION
The `[[interceptor]]` manifest block is removed in astrid#863 (Closes astrid#858) — interceptors are now a `[subscribe]` entry with a `handler`. Updates the `interceptors` module doc comments (`interceptors.rs`, `lib.rs`) to describe the current form.

Doc-only — the SDK never parsed `Capsule.toml`, so no code change is needed for the manifest-schema migration.