### PR TITLE
fix(macros): tool_describe must publish its descriptor for the describe fan-out

### DIFF
--- a/astrid-sdk-macros/src/lib.rs
+++ b/astrid-sdk-macros/src/lib.rs
@@ -640,6 +640,27 @@ fn capsule_impl(
                     "description": capsule_desc.unwrap_or(""),
                 });
 
+                // Publish the descriptor on the describe-response topic. The
+                // `tool.v1.request.describe` fan-out (prompt-builder, registry,
+                // the sage-mcp MCP bridge) COLLECTS by subscribing to
+                // `tool.v1.response.describe.*` — under the current ABI an
+                // interceptor's return value is NOT fanned out to the caller, so
+                // the descriptor must be published explicitly (mirroring the
+                // hand-written LLM providers that publish `llm.v1.response.describe`).
+                // The route layer's trailing `*` needs >= 5 segments; the
+                // responder's real source_id rides in the kernel-stamped message
+                // metadata, so the fixed `self` suffix exists only to satisfy that
+                // routing arity. Best-effort: a failed publish only omits this
+                // capsule's tools from the fan-out (logged, never a hard error).
+                if let Err(e) = ::astrid_sdk::prelude::ipc::publish_json(
+                    "tool.v1.response.describe.self",
+                    &response,
+                ) {
+                    ::astrid_sdk::prelude::log::warn(format!(
+                        "tool_describe: failed to publish descriptor, tools absent from describe fan-out: {e:?}"
+                    ));
+                }
+
                 let data = match ::serde_json::to_string(&response) {
                     Ok(s) => s,
                     Err(e) => {
@@ -941,6 +962,54 @@ mod tests {
         assert!(
             output.contains("json ! (true)"),
             "Inline mutable should produce json!(true), got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn tool_describe_publishes_response_for_fanout() {
+        // Regression guard: the generated `tool_describe` arm MUST publish its
+        // descriptor on `tool.v1.response.describe.*`. Under the current ABI an
+        // interceptor's return value is NOT fanned out to the caller, so a
+        // return-only describe silently fails the `tool.v1.request.describe`
+        // fan-out and prompt-builder / registry / the sage-mcp MCP bridge
+        // collect 0 tools. Guard against regressing to return-only.
+        let attr = quote::quote! {};
+        let input = quote::quote! {
+            impl MyCapsule {
+                #[astrid::tool("read_file")]
+                fn read_file(&self, args: ReadArgs) -> Result<ReadResult, Error> {
+                    todo!()
+                }
+            }
+        };
+        let output = capsule_impl(attr, input).to_string();
+        assert!(
+            output.contains("publish_json"),
+            "tool_describe must call ipc::publish_json for the describe fan-out, got:\n{output}"
+        );
+        assert!(
+            output.contains("tool.v1.response.describe.self"),
+            "tool_describe must publish on tool.v1.response.describe.* for the fan-out, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn capsule_without_tools_has_no_describe_publish() {
+        // A capsule with no #[tool] methods generates no tool_describe arm, so it
+        // must not emit a stray describe-response publish.
+        let attr = quote::quote! {};
+        let input = quote::quote! {
+            impl MyCapsule {
+                #[astrid::interceptor("on_event")]
+                fn on_event(&self, payload: serde_json::Value) -> Result<(), Error> {
+                    todo!()
+                }
+            }
+        };
+        let output = capsule_impl(attr, input).to_string();
+        assert!(
+            !output.contains("tool.v1.response.describe"),
+            "capsule without tools should not publish a describe response, got:\n{output}"
         );
     }
 


### PR DESCRIPTION
## What & why

The `#[capsule]` macro auto-generates a `tool_describe` interceptor arm for any capsule with `#[astrid::tool]` methods. It built the `{tools, description}` descriptor and **returned** it as a `CapsuleResult{action:"continue", ...}` — but **under the current ABI an interceptor's return value is no longer fanned out to the caller** (the dispatcher drops a lone request handler's Continue payload). So no SDK-macro tool capsule (`fs`, `http`, `identity`, `system`, `skills`) ever answered the `tool.v1.request.describe` fan-out, and **every consumer collected 0 tools**: prompt-builder, registry, and the sage-mcp MCP bridge behind `astrid mcp serve` (`tools/list` returned `{tools:[]}` on a healthy daemon).

The hand-written LLM providers already do this correctly — `astrid-capsule-openai::llm_describe` ends with `ipc::publish_json("llm.v1.response.describe", ...)` and its doc says verbatim *"the interceptor return value is no longer fanned out to the caller under the new ABI."* The macro was simply never updated to match.

## Fix

Publish the descriptor explicitly on `tool.v1.response.describe.self` before returning (the Continue return is kept for interceptor-chain semantics). One-site change that fixes every SDK-macro tool capsule at once.

**Topic suffix is routing-only.** Consumers subscribe `tool.v1.response.describe.*`; the route-layer trailing `*` requires ≥ 5 segments (a 4-seg unsuffixed publish would not match), and the responder's real `source_id` rides in the kernel-stamped message metadata (`msg.source_id`, which prompt-builder uses for per-source permission filtering), so a fixed `self` suffix is sufficient. Subscribers parse `tools` from the payload, not the topic. No self-id accessor exists in the SDK today.

## Verification

- `cargo test -p astrid-sdk-macros` — 46 pass, including the new `tool_describe_publishes_response_for_fanout` regression guard and `capsule_without_tools_has_no_describe_publish`.
- **End-to-end (local `[patch.crates-io]`):** rebuilt `astrid-capsule-fs` against this branch and reinstalled it; `astrid mcp serve` → `tools/list` went from **0 tools to 8** — fs's full set (`read_file`, `write_file`, `list_directory`, `grep_search`, `create_directory`, `delete_file`, `move_file`, `replace_in_file`). The other tool capsules still carry the old macro and contribute nothing until rebuilt, which confirms the fan-out now works and this is the sole gating change.

Landing the full surface: merge → publish `astrid-sdk` to crates.io → rebuild the tool capsules.

Root-cause companion: the empty `astrid mcp serve` tool surface traced back here; the cli-proxy daemon-down crash and MCP publish-ACL gap on the path were fixed separately in capsule-cli #25.
