### PR TITLE
docs(sdk): reference the [subscribe] handler form, not [[interceptor]]

### DIFF
--- a/astrid-sdk/src/interceptors.rs
+++ b/astrid-sdk/src/interceptors.rs
@@ -36,8 +36,8 @@ impl InterceptorBinding {
 /// Query the runtime for auto-subscribed interceptor handles.
 ///
 /// Returns an empty vec if this capsule has no auto-subscribed
-/// interceptors (i.e. it does not have both `run()` and
-/// `[[interceptor]]`). Each entry maps an action name to the IPC
+/// interceptors (i.e. it does not have both `run()` and a `[subscribe]`
+/// entry with a `handler`). Each entry maps an action name to the IPC
 /// topic the kernel routes through `astrid-hook-trigger`.
 pub fn bindings() -> Result<Vec<InterceptorBinding>, SysError> {
     let handles = wit_ipc::get_interceptor_bindings().map_err(host_err)?;

--- a/astrid-sdk/src/lib.rs
+++ b/astrid-sdk/src/lib.rs
@@ -522,10 +522,11 @@ pub mod elicit;
 
 /// Auto-subscribed interceptor bindings for run-loop capsules.
 ///
-/// When a capsule declares both `run()` and `[[interceptor]]`, the runtime
-/// auto-subscribes to each interceptor's topic and delivers events through
-/// the IPC channel the run loop already reads from. This module provides
-/// helpers to query the subscription mappings and dispatch events by action.
+/// When a capsule declares both `run()` and a `[subscribe]` entry with a
+/// `handler`, the runtime auto-subscribes to each interceptor's topic and
+/// delivers events through the IPC channel the run loop already reads from.
+/// This module provides helpers to query the subscription mappings and
+/// dispatch events by action.
 pub mod interceptors;
 
 /// Request human approval for sensitive actions from within a capsule.


### PR DESCRIPTION
Updates the `interceptors` module doc comments (interceptors.rs, lib.rs) from the removed `[[interceptor]]` manifest block to the current `[subscribe]` entry with a `handler` (astrid#863). Doc-only — the SDK never parsed Capsule.toml.

Supersedes #52, which carried a regressive contracts-submodule downgrade to an old wit feat-branch commit; this re-does just the doc fix cleanly on current main.