### PR TITLE
Point Rust SDK at Astrid Runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "contracts"]
 	path = contracts
-	url = https://github.com/unicity-astrid/wit.git
+	url = https://github.com/astrid-runtime/wit.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.7.1"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/unicity-astrid/sdk-rust"
+repository = "https://github.com/astrid-runtime/sdk-rust"
 rust-version = "1.94"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The Rust SDK for building [Astrid](https://github.com/unicity-astrid/astrid) capsules.**
+**The Rust SDK for building [Astrid](https://github.com/astrid-runtime/astrid) capsules.**
 
 In the OS model, this is the standard library for user-space processes. It gives capsule authors safe, typed access to every kernel service: filesystem, IPC, networking, storage, approval, scheduling, and more. Capsule authors depend on `astrid-sdk` and `serde`. Everything else is handled.
 

--- a/astrid-sdk/src/lib.rs
+++ b/astrid-sdk/src/lib.rs
@@ -186,7 +186,7 @@ pub mod fs;
 ///
 /// These types are the standard payloads for cross-capsule IPC topics
 /// (LLM requests, session messages, registry events, etc.). They are
-/// generated from the `unicity-astrid/wit` repository which defines
+/// generated from the `astrid-runtime/wit` repository which defines
 /// the canonical WIT interfaces.
 ///
 /// Capsule authors use these types with [`ipc::publish_json`] instead

--- a/astrid-sdk/wit/astrid-contracts.wit
+++ b/astrid-sdk/wit/astrid-contracts.wit
@@ -3,7 +3,7 @@
 // Concatenated from contracts/interfaces/*.wit by
 // scripts/sync-contracts-wit.sh.
 //
-// Source of truth: unicity-astrid/wit (git submodule at contracts/).
+// Source of truth: astrid-runtime/wit (git submodule at contracts/).
 // Run `scripts/sync-contracts-wit.sh` after pulling the submodule to
 // regenerate this file; CI fails if it drifts from the canonical set.
 
@@ -1463,4 +1463,3 @@ interface users {
         error: option<string>,
     }
 }
-

--- a/astrid-sdk/wit/astrid-contracts.wit
+++ b/astrid-sdk/wit/astrid-contracts.wit
@@ -1463,3 +1463,4 @@ interface users {
         error: option<string>,
     }
 }
+

--- a/astrid-sys/build.rs
+++ b/astrid-sys/build.rs
@@ -2,7 +2,7 @@
 //!
 //! Stages the WIT submodule into a layout `wit_bindgen::generate!` can
 //! resolve. The canonical WIT lives at `sdk-rust/contracts/` (a submodule
-//! of `unicity-astrid/wit`) with per-domain packages under `host/` and
+//! of `astrid-runtime/wit`) with per-domain packages under `host/` and
 //! the guest-side lifecycle worlds under `host/guest@1.0.0.wit`.
 //!
 //! wit-bindgen expects a single root directory with one package per
@@ -48,7 +48,7 @@ fn main() {
     let staging = crate_root.join("wit-staging");
     let deps = staging.join("deps");
 
-    // Published-crate path: the `unicity-astrid/wit` submodule isn't
+    // Published-crate path: the `astrid-runtime/wit` submodule isn't
     // available on a consumer's machine. The committed `wit-staging/`
     // ships with the crate; `src/lib.rs`'s `wit_bindgen::generate!`
     // reads it directly. Skip the stage step.

--- a/astrid-sys/src/lib.rs
+++ b/astrid-sys/src/lib.rs
@@ -1,7 +1,7 @@
 //! Component Model bindings for the Astrid OS System API (The Airlocks).
 //!
 //! This crate generates typed guest bindings from the per-domain WIT
-//! packages in `contracts/host/` (the `unicity-astrid/wit` submodule).
+//! packages in `contracts/host/` (the `astrid-runtime/wit` submodule).
 //! `build.rs` stages those files into `wit-staging/deps/astrid-<pkg>@<version>/`;
 //! a single [`wit_bindgen::generate!`] invocation then emits one Rust
 //! module per package under a synthetic `capsule` world that imports

--- a/scripts/sync-contracts-wit.sh
+++ b/scripts/sync-contracts-wit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Sync astrid-sdk/wit/astrid-contracts.wit from the canonical
-# unicity-astrid/wit submodule (at contracts/interfaces/*.wit).
+# astrid-runtime/wit submodule (at contracts/interfaces/*.wit).
 #
 # Why this exists, in two parts:
 #
@@ -59,7 +59,7 @@ generate() {
 // Concatenated from contracts/interfaces/*.wit by
 // scripts/sync-contracts-wit.sh.
 //
-// Source of truth: unicity-astrid/wit (git submodule at contracts/).
+// Source of truth: astrid-runtime/wit (git submodule at contracts/).
 // Run `scripts/sync-contracts-wit.sh` after pulling the submodule to
 // regenerate this file; CI fails if it drifts from the canonical set.
 


### PR DESCRIPTION
## Summary

Updates Rust SDK repository metadata, WIT submodule origin, and current source links to Astrid Runtime.

## Compatibility

Published crate names and WIT namespaces are unchanged.

## Verification

- git diff --check
- bash -n scripts/sync-contracts-wit.sh