### PR TITLE
feat(sdk): expose heterogeneous readiness polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Readiness multiplexing wrappers.** New `io::{Pollable, poll,
+  MAX_POLLABLES_PER_CALL}` safely expose the existing `astrid:io/poll@1.0.0`
+  host contract. `ipc::Subscription::subscribe_readiness`,
+  `net::UnixListener::subscribe_readiness`, and
+  `net::TcpStream::subscribe_readable` let run-loop capsules wait once across
+  heterogeneous resources instead of timeout-scanning every handle.
+
 - **`astrid:http@1.1.0` per-request controls.** The `http` module moves to the additive `@1.1.0`
   host interface; an unset option reproduces `@1.0.0` behaviour exactly. New `Request` builders:
   `.timeout(Duration)` (total), `.connect_timeout`, `.first_byte_timeout`, `.read_timeout`

--- a/astrid-sdk/src/io.rs
+++ b/astrid-sdk/src/io.rs
@@ -1,0 +1,68 @@
+//! Heterogeneous readiness polling for capsule host resources.
+//!
+//! A [`Pollable`] borrows its source resource host-side, so it must be dropped
+//! before the listener, stream, subscription, or process handle that created
+//! it. Keeping both values in the same scope naturally enforces that order.
+
+use astrid_sys::astrid::io::poll as wit_poll;
+
+use crate::{SysError, host_err};
+
+/// Maximum number of handles accepted by one [`poll`] call.
+pub const MAX_POLLABLES_PER_CALL: usize = 256;
+
+/// An opaque readiness signal created by another SDK resource.
+#[derive(Debug)]
+pub struct Pollable {
+    pub(crate) inner: wit_poll::Pollable,
+}
+
+impl Pollable {
+    pub(crate) fn new(inner: wit_poll::Pollable) -> Self {
+        Self { inner }
+    }
+
+    /// Return immediately with the current readiness state.
+    #[must_use]
+    pub fn ready(&self) -> bool {
+        self.inner.ready()
+    }
+
+    /// Block until this signal is ready or the capsule is unloading.
+    pub fn block(&self) -> Result<(), SysError> {
+        self.inner.block().map_err(host_err)
+    }
+}
+
+/// Block until one or more signals are ready and return their input indices.
+///
+/// The input must contain between 1 and [`MAX_POLLABLES_PER_CALL`] handles.
+/// Returned indices are sorted and unique.
+pub fn poll(pollables: &[&Pollable]) -> Result<Vec<usize>, SysError> {
+    if pollables.is_empty() {
+        return Err(SysError::ApiError(
+            "poll requires at least one pollable".to_string(),
+        ));
+    }
+    if pollables.len() > MAX_POLLABLES_PER_CALL {
+        return Err(SysError::ApiError(format!(
+            "poll accepts at most {MAX_POLLABLES_PER_CALL} pollables"
+        )));
+    }
+
+    let raw: Vec<&wit_poll::Pollable> = pollables.iter().map(|pollable| &pollable.inner).collect();
+    wit_poll::poll(&raw)
+        .map(|indices| indices.into_iter().map(|index| index as usize).collect())
+        .map_err(host_err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_rejects_empty_input_before_calling_the_host() {
+        let error = poll(&[]).expect_err("empty poll set should fail");
+        assert!(error.to_string().contains("at least one"));
+    }
+}

--- a/astrid-sdk/src/ipc.rs
+++ b/astrid-sdk/src/ipc.rs
@@ -26,6 +26,14 @@ pub struct Subscription {
 }
 
 impl Subscription {
+    /// Create a signal that becomes ready when messages are queued.
+    ///
+    /// Drop the returned pollable before dropping this subscription.
+    #[must_use]
+    pub fn subscribe_readiness(&self) -> crate::io::Pollable {
+        crate::io::Pollable::new(self.inner.subscribe_readiness())
+    }
+
     /// Non-blocking poll for messages queued since the last
     /// `poll` / `recv` on this subscription.
     pub fn poll(&self) -> Result<PollResult, SysError> {

--- a/astrid-sdk/src/lib.rs
+++ b/astrid-sdk/src/lib.rs
@@ -196,6 +196,7 @@ pub mod contracts {
     astrid_sdk_macros::wit_events!("wit/astrid-contracts.wit");
 }
 
+pub mod io;
 /// Event bus messaging (like `std::sync::mpsc` but topic-based).
 pub mod ipc;
 
@@ -661,6 +662,7 @@ pub mod prelude {
         http,
         identity,
         interceptors,
+        io,
         ipc,
         kv,
         log,

--- a/astrid-sdk/src/net.rs
+++ b/astrid-sdk/src/net.rs
@@ -115,6 +115,14 @@ pub struct UnixListener {
 }
 
 impl UnixListener {
+    /// Create a signal that becomes ready when a connection can be accepted.
+    ///
+    /// Drop the returned pollable before dropping this listener.
+    #[must_use]
+    pub fn subscribe_readiness(&self) -> crate::io::Pollable {
+        crate::io::Pollable::new(self.inner.subscribe_readiness())
+    }
+
     /// Blocking accept of the next inbound Unix-domain connection.
     pub fn accept(&self) -> Result<TcpStream, SysError> {
         let inner = self.inner.accept().map_err(host_err)?;
@@ -169,6 +177,15 @@ pub struct TcpStream {
 }
 
 impl TcpStream {
+    /// Create a signal that becomes ready when a read can make progress or the
+    /// peer has closed the connection.
+    ///
+    /// Drop the returned pollable before dropping this stream.
+    #[must_use]
+    pub fn subscribe_readable(&self) -> crate::io::Pollable {
+        crate::io::Pollable::new(self.inner.subscribe_readable())
+    }
+
     /// Open an outbound TCP connection to `host:port`.
     ///
     /// DNS resolution and the SSRF airlock run host-side; the WASM


### PR DESCRIPTION
## Linked Issue

Closes #64

## Summary

Expose the canonical heterogeneous readiness surface through safe Rust SDK wrappers so capsules can multiplex IPC subscriptions, listeners, and streams without timeout polling.

## Changes

- add an opaque `io::Pollable` wrapper with `ready` and `block`
- add `io::poll` with SDK-side empty-list and 256-handle validation
- expose readiness subscriptions on IPC subscriptions, Unix listeners, and network streams
- document borrowed-resource drop ordering and export the module through the prelude
- add SDK validation coverage and an `[Unreleased]` changelog entry

## Verification

- `cargo check --workspace --offline`
- `cargo test -p astrid-sdk --offline` (39 unit tests plus smoke and doc tests)
- GitHub CI Clippy passed for the workspace
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
